### PR TITLE
Optimize hic PixelSelector

### DIFF
--- a/src/hic/CMakeLists.txt
+++ b/src/hic/CMakeLists.txt
@@ -18,13 +18,15 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/header_impl.hpp
             ${CMAKE_CURRENT_SOURCE_DIR}/index_impl.hpp
             ${CMAKE_CURRENT_SOURCE_DIR}/pixel_selector_impl.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/utils_impl.hpp)
+            ${CMAKE_CURRENT_SOURCE_DIR}/utils_impl.hpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/weight_cache_impl.hpp)
 
 target_include_directories(hic INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(
   hic
   INTERFACE hictk_project_options
             hictk_project_warnings
+            hictk::balancing
             hictk::common
             hictk::chromosome
             hictk::reference)

--- a/src/hic/file_reader_impl.hpp
+++ b/src/hic/file_reader_impl.hpp
@@ -204,7 +204,8 @@ inline Index HiCFileReader::read_index(std::int64_t fileOffset, const Chromosome
 
     const auto nBlocks = static_cast<std::size_t>(_fs->read<std::int32_t>());
 
-    Index::BlockIndexMap buffer;
+    Index::BlkIdxBuffer buffer;
+    buffer.reserve(nBlocks);
     if (wantedUnit == foundUnit && wantedResolution == foundResolution) {
       for (std::size_t j = 0; j < nBlocks; ++j) {
         const auto block_id = static_cast<std::size_t>(_fs->read<std::int32_t>());
@@ -212,9 +213,11 @@ inline Index HiCFileReader::read_index(std::int64_t fileOffset, const Chromosome
         const auto size = static_cast<std::size_t>(_fs->read<std::int32_t>());
         assert(position + size < _fs->size());
         if (size > 0) {
-          buffer.emplace(block_id, position, size, blockColumnCount);
+          buffer.emplace_back(block_id, position, size, blockColumnCount);
         }
       }
+
+      buffer.shrink_to_fit();
 
       return {chrom1,           chrom2,
               wantedUnit,       static_cast<std::uint32_t>(wantedResolution),

--- a/src/hic/file_reader_impl.hpp
+++ b/src/hic/file_reader_impl.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 
+#include "hictk/balancing/weights.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/filestream.hpp"
 #include "hictk/hic/index.hpp"
@@ -362,8 +363,9 @@ inline bool HiCFileReader::checkMagicString(std::string url) noexcept {
 
 inline HiCFooter HiCFileReader::read_footer(std::uint32_t chrom1_id, std::uint32_t chrom2_id,
                                             MatrixType matrix_type, NormalizationMethod wanted_norm,
-                                            MatrixUnit wanted_unit,
-                                            std::uint32_t wanted_resolution) {
+                                            MatrixUnit wanted_unit, std::uint32_t wanted_resolution,
+                                            std::shared_ptr<balancing::Weights> weights1,
+                                            std::shared_ptr<balancing::Weights> weights2) {
   assert(chrom1_id <= chrom2_id);
   assert(std::find(_header->resolutions.begin(), _header->resolutions.end(), wanted_resolution) !=
          _header->resolutions.end());
@@ -398,32 +400,23 @@ inline HiCFooter HiCFileReader::read_footer(std::uint32_t chrom1_id, std::uint32
     }
   }
   if (metadata.fileOffset == -1) {
-    const auto num_bins1 = (metadata.chrom1.size() + wanted_resolution - 1) / wanted_resolution;
-    const auto num_bins2 = (metadata.chrom2.size() + wanted_resolution - 1) / wanted_resolution;
-
-    auto f = HiCFooter{Index{}, std::move(metadata)};
-    f.c1Norm() = std::vector<double>(num_bins1, std::numeric_limits<double>::quiet_NaN());
-    f.c2Norm() = std::vector<double>(num_bins2, std::numeric_limits<double>::quiet_NaN());
-    return f;
+    return {Index{}, std::move(metadata), {}, std::move(weights1), std::move(weights2)};
   }
 
   const auto file_offset = _fs->tellg();
   // NOTE: we read then move index to workaround assertion failures when compiling under MSVC
   auto index = read_index(metadata.fileOffset, metadata.chrom1, metadata.chrom2, metadata.unit,
                           metadata.resolution);
-  HiCFooter footer{std::move(index), std::move(metadata)};
   _fs->seekg(static_cast<std::int64_t>(file_offset));
 
   if ((matrix_type == MT::observed && wanted_norm == NM::NONE) ||
       ((matrix_type == MT::oe || matrix_type == MT::expected) && wanted_norm == NM::NONE &&
        chrom1_id != chrom2_id)) {
-    return footer;  // no need to read wanted_norm vector index
+    // no need to read wanted_norm vector index
+    return {std::move(index), std::move(metadata), {}, std::move(weights1), std::move(weights2)};
   }
 
-  auto &expectedValues = footer.expectedValues();
-  auto &c1Norm = footer.c1Norm();
-  auto &c2Norm = footer.c2Norm();
-
+  std::vector<double> expectedValues{};
   auto nExpectedValues = _fs->read<std::int32_t>();
   for (std::int32_t i = 0; i < nExpectedValues; ++i) {
     const auto foundUnit = readMatrixUnit();
@@ -453,7 +446,8 @@ inline HiCFooter HiCFileReader::read_footer(std::uint32_t chrom1_id, std::uint32
                       _header->chromosomes.at(chrom1_id).name(),
                       _header->chromosomes.at(chrom2_id).name(), wanted_resolution, wanted_unit));
     }
-    return footer;
+    return {std::move(index), std::move(metadata), std::move(expectedValues), std::move(weights1),
+            std::move(weights2)};
   }
 
   nExpectedValues = _fs->read<std::int32_t>();
@@ -499,39 +493,48 @@ inline HiCFooter HiCFileReader::read_footer(std::uint32_t chrom1_id, std::uint32
     const auto filePosition = _fs->read<std::int64_t>();
     const auto sizeInBytes = version() > 8 ? _fs->read<std::int64_t>()
                                            : static_cast<std::int64_t>(_fs->read<std::int32_t>());
-    if (foundChrom == chrom1_id && foundNorm == wanted_norm && foundUnit == wanted_unit &&
-        foundResolution == wanted_resolution) {
+
+    const auto store1 = !*weights1 && foundChrom == chrom1_id && foundNorm == wanted_norm &&
+                        foundUnit == wanted_unit && foundResolution == wanted_resolution;
+    if (store1) {
       const auto numBins = static_cast<std::size_t>(
-          (footer.chrom1().size() + wanted_resolution - 1) / wanted_resolution);
+          (metadata.chrom1.size() + wanted_resolution - 1) / wanted_resolution);
       const auto currentPos = static_cast<std::int64_t>(this->_fs->tellg());
-      c1Norm = readNormalizationVector(indexEntry{filePosition, sizeInBytes}, numBins);
+      *weights1 = balancing::Weights{
+          readNormalizationVector(indexEntry{filePosition, sizeInBytes}, numBins),
+          balancing::Weights::Type::DIVISIVE};
       _fs->seekg(currentPos);
     }
-    if (chrom1_id != chrom2_id && foundChrom == chrom2_id && foundNorm == wanted_norm &&
-        foundUnit == wanted_unit && foundResolution == wanted_resolution) {
+
+    const auto store2 = !*weights2 && foundChrom == chrom2_id && foundNorm == wanted_norm &&
+                        foundUnit == wanted_unit && foundResolution == wanted_resolution;
+    if (store2) {
       const auto numBins = static_cast<std::size_t>(
-          (footer.chrom2().size() + wanted_resolution - 1) / wanted_resolution);
+          (metadata.chrom2.size() + wanted_resolution - 1) / wanted_resolution);
       const auto currentPos = static_cast<std::int64_t>(this->_fs->tellg());
-      c2Norm = readNormalizationVector(indexEntry{filePosition, sizeInBytes}, numBins);
+      *weights2 = balancing::Weights{
+          readNormalizationVector(indexEntry{filePosition, sizeInBytes}, numBins),
+          balancing::Weights::Type::DIVISIVE};
       _fs->seekg(currentPos);
     }
   }
 
-  if (footer.c1Norm().empty() && footer.c2Norm().empty()) {
+  if (!*weights1 && !*weights2) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("unable to find {} normalization vectors for {}:{} at {} ({})"),
                     wanted_norm, _header->chromosomes.at(chrom1_id).name(),
                     _header->chromosomes.at(chrom2_id).name(), wanted_resolution, wanted_unit));
   }
 
-  if (footer.c1Norm().empty() || footer.c2Norm().empty()) {
-    const auto chrom_id = footer.c1Norm().empty() ? chrom1_id : chrom2_id;
+  if (!*weights1 || !*weights2) {
+    const auto chrom_id = !*weights1 ? chrom1_id : chrom2_id;
     throw std::runtime_error(fmt::format(
         FMT_STRING("unable to find {} normalization vector for {} at {} ({})"), wanted_norm,
         _header->chromosomes.at(chrom_id).name(), wanted_resolution, wanted_unit));
   }
 
-  return footer;
+  return {std::move(index), std::move(metadata), std::move(expectedValues), std::move(weights1),
+          std::move(weights2)};
 }
 
 }  // namespace hictk::hic::internal

--- a/src/hic/file_reader_impl.hpp
+++ b/src/hic/file_reader_impl.hpp
@@ -214,11 +214,9 @@ inline Index HiCFileReader::read_index(std::int64_t fileOffset, const Chromosome
         const auto size = static_cast<std::size_t>(_fs->read<std::int32_t>());
         assert(position + size < _fs->size());
         if (size > 0) {
-          buffer.emplace_back(block_id, position, size, blockColumnCount);
+          buffer.emplace(block_id, position, size, blockColumnCount);
         }
       }
-
-      buffer.shrink_to_fit();
 
       return {chrom1,           chrom2,
               wantedUnit,       static_cast<std::uint32_t>(wantedResolution),

--- a/src/hic/file_reader_impl.hpp
+++ b/src/hic/file_reader_impl.hpp
@@ -204,7 +204,7 @@ inline Index HiCFileReader::read_index(std::int64_t fileOffset, const Chromosome
 
     const auto nBlocks = static_cast<std::size_t>(_fs->read<std::int32_t>());
 
-    phmap::flat_hash_set<BlockIndex, BlockIndexHasher, BlockIndexEq> buffer;
+    Index::BlockIndexMap buffer;
     if (wantedUnit == foundUnit && wantedResolution == foundResolution) {
       for (std::size_t j = 0; j < nBlocks; ++j) {
         const auto block_id = static_cast<std::size_t>(_fs->read<std::int32_t>());

--- a/src/hic/footer_cache_impl.hpp
+++ b/src/hic/footer_cache_impl.hpp
@@ -52,25 +52,27 @@ inline std::size_t FooterCache::HiCFooterPtrHasher::operator()(
   return std::hash<HiCFooterMetadata>{}(m);
 }
 
-inline auto FooterCache::begin() const noexcept -> decltype(_cache.cbegin()) {
-  return _cache.begin();
+inline auto FooterCache::begin() const noexcept -> decltype(_footers.cbegin()) {
+  return _footers.begin();
 }
-inline auto FooterCache::end() const noexcept -> decltype(_cache.cbegin()) { return _cache.end(); }
-
-inline auto FooterCache::cbegin() const noexcept -> decltype(_cache.cbegin()) {
-  return _cache.cbegin();
-}
-inline auto FooterCache::cend() const noexcept -> decltype(_cache.cbegin()) {
-  return _cache.cend();
+inline auto FooterCache::end() const noexcept -> decltype(_footers.cbegin()) {
+  return _footers.end();
 }
 
-inline auto FooterCache::emplace(HiCFooter &&f) -> decltype(_cache.emplace()) {
-  return _cache.emplace(std::make_shared<const HiCFooter>(std::move(f)));
+inline auto FooterCache::cbegin() const noexcept -> decltype(_footers.cbegin()) {
+  return _footers.cbegin();
+}
+inline auto FooterCache::cend() const noexcept -> decltype(_footers.cbegin()) {
+  return _footers.cend();
+}
+
+inline auto FooterCache::emplace(HiCFooter f) -> decltype(_footers.emplace()) {
+  return _footers.emplace(std::make_shared<const HiCFooter>(std::move(f)));
 }
 inline auto FooterCache::find(const HiCFooterMetadata &m) -> const_iterator {
-  return _cache.find(m);
+  return _footers.find(m);
 }
-inline std::size_t FooterCache::size() const noexcept { return _cache.size(); }
-inline void FooterCache::clear() { return _cache.clear(); }
+inline std::size_t FooterCache::size() const noexcept { return _footers.size(); }
+inline void FooterCache::clear() { return _footers.clear(); }
 
 }  // namespace hictk::hic::internal

--- a/src/hic/footer_impl.hpp
+++ b/src/hic/footer_impl.hpp
@@ -24,8 +24,15 @@ inline bool HiCFooterMetadata::operator!=(const HiCFooterMetadata &other) const 
   return !(*this == other);
 }
 
-inline HiCFooter::HiCFooter(Index index_, HiCFooterMetadata metadata_) noexcept
-    : _index(std::move(index_)), _metadata(std::move(metadata_)) {}
+inline HiCFooter::HiCFooter(Index index_, HiCFooterMetadata metadata_,
+                            std::vector<double> expected_values,
+                            std::shared_ptr<balancing::Weights> weights1,
+                            std::shared_ptr<balancing::Weights> weights2) noexcept
+    : _index(std::move(index_)),
+      _metadata(std::move(metadata_)),
+      _expectedValues(std::move(expected_values)),
+      _weights1(std::move(weights1)),
+      _weights2(std::move(weights2)) {}
 
 constexpr HiCFooter::operator bool() const noexcept { return !metadata(); }
 inline bool HiCFooter::operator==(const HiCFooter &other) const noexcept {
@@ -52,26 +59,17 @@ constexpr const std::vector<double> &HiCFooter::expectedValues() const noexcept 
   return _expectedValues;
 }
 
-constexpr const std::vector<double> &HiCFooter::c1Norm() const noexcept { return _c1Norm; }
+inline const balancing::Weights &HiCFooter::weights1() const noexcept {
+  assert(_weights1);
+  return *_weights1;
+}
 
-constexpr const std::vector<double> &HiCFooter::c2Norm() const noexcept {
-  if (chrom1().id() == chrom2().id()) {
-    return _c1Norm;
-  }
-  return _c2Norm;
+inline const balancing::Weights &HiCFooter::weights2() const noexcept {
+  assert(_weights2);
+  return *_weights2;
 }
 
 constexpr std::vector<double> &HiCFooter::expectedValues() noexcept { return _expectedValues; }
-
-constexpr std::vector<double> &HiCFooter::c1Norm() noexcept { return _c1Norm; }
-
-constexpr std::vector<double> &HiCFooter::c2Norm() noexcept {
-  if (chrom1().id() == chrom2().id()) {
-    return _c1Norm;
-  }
-  return _c2Norm;
-}
-
 }  // namespace hictk::hic::internal
 
 inline std::size_t std::hash<hictk::hic::internal::HiCFooterMetadata>::operator()(

--- a/src/hic/hic_file_impl.hpp
+++ b/src/hic/hic_file_impl.hpp
@@ -189,17 +189,15 @@ inline void HiCFile::optimize_cache_size(std::size_t upper_bound) {
 
 inline void HiCFile::optimize_cache_size_for_iteration(std::size_t upper_bound) {
   std::size_t cache_size = this->estimate_cache_size_cis() + this->estimate_cache_size_trans();
-  cache_size = cache_size * 10 / 9;  // Better to slighly overestimate than underestimate
-  cache_size =
-      std::max(cache_size, std::size_t(10'000'000));  // 10MBs seems like a reasonable lower bound
+  // Better to overestimate than underestimate cache size
+  cache_size = std::max(4 * cache_size / 3, std::size_t(10'000'000));
+
   _block_cache->set_capacity(std::min(upper_bound, cache_size));
 }
 
 inline void HiCFile::optimize_cache_size_for_random_access(std::size_t upper_bound) {
   std::size_t cache_size = this->estimate_cache_size_cis();
-  cache_size = cache_size * 10 / 9;  // Better to slighly overestimate than underestimate
-  cache_size =
-      std::max(cache_size, std::size_t(10'000'000));  // 10MBs seems like a reasonable lower bound
+  cache_size = std::max(4 * cache_size / 3, std::size_t(10'000'000));
   _block_cache->set_capacity(std::min(upper_bound, cache_size));
 }
 

--- a/src/hic/include/hictk/hic.hpp
+++ b/src/hic/include/hictk/hic.hpp
@@ -12,8 +12,8 @@
 #include <utility>
 #include <vector>
 
-#include "hictk/hic/block_cache.hpp"
 #include "hictk/hic/block_reader.hpp"
+#include "hictk/hic/cache.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/file_reader.hpp"
 #include "hictk/hic/filestream.hpp"
@@ -31,6 +31,7 @@ class HiCFile {
   MatrixType _type{MatrixType::observed};
   MatrixUnit _unit{MatrixUnit::BP};
   mutable std::shared_ptr<internal::BlockCache> _block_cache{};
+  mutable std::shared_ptr<internal::WeightCache> _weight_cache{};
   std::shared_ptr<const BinTable> _bins{};
 
  public:

--- a/src/hic/include/hictk/hic/block_reader.hpp
+++ b/src/hic/include/hictk/hic/block_reader.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>
 
 #include "hictk/chromosome.hpp"
-#include "hictk/hic/block_cache.hpp"
+#include "hictk/hic/cache.hpp"
 #include "hictk/hic/file_reader.hpp"
 #include "hictk/hic/index.hpp"
 

--- a/src/hic/include/hictk/hic/cache.hpp
+++ b/src/hic/include/hictk/hic/cache.hpp
@@ -121,6 +121,21 @@ class BlockCache {
   void pop_oldest();
 };
 
+class WeightCache {
+  using Value = std::shared_ptr<balancing::Weights>;
+  phmap::flat_hash_map<std::pair<std::uint32_t, NormalizationMethod>, Value> _weights{};
+
+ public:
+  WeightCache() = default;
+
+  [[nodiscard]] auto find_or_emplace(std::uint32_t chrom_id, NormalizationMethod norm) -> Value;
+  [[nodiscard]] auto find_or_emplace(const Chromosome& chrom, NormalizationMethod norm) -> Value;
+
+  void clear() noexcept;
+  [[nodiscard]] std::size_t size() const noexcept;
+};
+
 }  // namespace hictk::hic::internal
 
 #include "../../../block_cache_impl.hpp"
+#include "../../../weight_cache_impl.hpp"

--- a/src/hic/include/hictk/hic/file_reader.hpp
+++ b/src/hic/include/hictk/hic/file_reader.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "hictk/balancing/weights.hpp"
 #include "hictk/chromosome.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/filestream.hpp"
@@ -38,9 +39,11 @@ class HiCFileReader {
 
   // reads the footer given a pair of chromosomes, wanted_norm, wanted_unit (BP or FRAG) and
   // resolution.
-  [[nodiscard]] HiCFooter read_footer(std::uint32_t chrom1_id, std::uint32_t chrom2_id,
-                                      MatrixType matrix_type, NormalizationMethod wanted_norm,
-                                      MatrixUnit wanted_unit, std::uint32_t wanted_resolution);
+  [[nodiscard]] HiCFooter read_footer(
+      std::uint32_t chrom1_id, std::uint32_t chrom2_id, MatrixType matrix_type,
+      NormalizationMethod wanted_norm, MatrixUnit wanted_unit, std::uint32_t wanted_resolution,
+      std::shared_ptr<balancing::Weights> weights1 = std::make_shared<balancing::Weights>(),
+      std::shared_ptr<balancing::Weights> weights2 = std::make_shared<balancing::Weights>());
 
   [[nodiscard]] static MatrixType readMatrixType(filestream::FileStream &fs, std::string &buff);
   [[nodiscard]] static NormalizationMethod readNormalizationMethod(filestream::FileStream &fs,

--- a/src/hic/include/hictk/hic/footer.hpp
+++ b/src/hic/include/hictk/hic/footer.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "hictk/balancing/weights.hpp"
 #include "hictk/chromosome.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/index.hpp"
@@ -33,12 +34,14 @@ class HiCFooter {
   Index _index{};
   HiCFooterMetadata _metadata{};
   std::vector<double> _expectedValues{};
-  std::vector<double> _c1Norm{};
-  std::vector<double> _c2Norm{};
+  std::shared_ptr<balancing::Weights> _weights1{};
+  std::shared_ptr<balancing::Weights> _weights2{};
 
  public:
   HiCFooter() = default;
-  explicit HiCFooter(Index index_, HiCFooterMetadata metadata_) noexcept;
+  HiCFooter(Index index_, HiCFooterMetadata metadata_, std::vector<double> expected_values,
+            std::shared_ptr<balancing::Weights> weights1,
+            std::shared_ptr<balancing::Weights> weights2) noexcept;
 
   constexpr explicit operator bool() const noexcept;
   bool operator==(const HiCFooter &other) const noexcept;
@@ -58,12 +61,10 @@ class HiCFooter {
   [[nodiscard]] constexpr std::int64_t fileOffset() const noexcept;
 
   [[nodiscard]] constexpr const std::vector<double> &expectedValues() const noexcept;
-  [[nodiscard]] constexpr const std::vector<double> &c1Norm() const noexcept;
-  [[nodiscard]] constexpr const std::vector<double> &c2Norm() const noexcept;
+  [[nodiscard]] const balancing::Weights &weights1() const noexcept;
+  [[nodiscard]] const balancing::Weights &weights2() const noexcept;
 
   [[nodiscard]] constexpr std::vector<double> &expectedValues() noexcept;
-  [[nodiscard]] constexpr std::vector<double> &c1Norm() noexcept;
-  [[nodiscard]] constexpr std::vector<double> &c2Norm() noexcept;
 };
 }  // namespace hictk::hic::internal
 

--- a/src/hic/include/hictk/hic/footer_cache.hpp
+++ b/src/hic/include/hictk/hic/footer_cache.hpp
@@ -36,23 +36,23 @@ class FooterCache {
     std::size_t operator()(const HiCFooterMetadata& m) const noexcept;
   };
 
-  using MapT =
+  using FooterMap =
       phmap::flat_hash_set<std::shared_ptr<const HiCFooter>, HiCFooterPtrHasher, HiCFooterPtrCmp>;
-  MapT _cache;
+  FooterMap _footers;
 
  public:
-  using difference_type = MapT::difference_type;
-  using iterator = MapT::iterator;
-  using const_iterator = MapT::iterator;
+  using difference_type = FooterMap::difference_type;
+  using iterator = FooterMap::iterator;
+  using const_iterator = FooterMap::iterator;
   FooterCache() = default;
 
-  [[nodiscard]] auto begin() const noexcept -> decltype(_cache.cbegin());
-  [[nodiscard]] auto end() const noexcept -> decltype(_cache.cbegin());
+  [[nodiscard]] auto begin() const noexcept -> decltype(_footers.cbegin());
+  [[nodiscard]] auto end() const noexcept -> decltype(_footers.cbegin());
 
-  [[nodiscard]] auto cbegin() const noexcept -> decltype(_cache.cbegin());
-  [[nodiscard]] auto cend() const noexcept -> decltype(_cache.cbegin());
+  [[nodiscard]] auto cbegin() const noexcept -> decltype(_footers.cbegin());
+  [[nodiscard]] auto cend() const noexcept -> decltype(_footers.cbegin());
 
-  [[nodiscard]] auto emplace(HiCFooter&& f) -> decltype(_cache.emplace());
+  [[nodiscard]] auto emplace(HiCFooter f) -> decltype(_footers.emplace());
   [[nodiscard]] auto find(const HiCFooterMetadata& m) -> const_iterator;
 
   [[nodiscard]] std::size_t size() const noexcept;

--- a/src/hic/include/hictk/hic/index.hpp
+++ b/src/hic/include/hictk/hic/index.hpp
@@ -20,20 +20,20 @@ namespace hictk::hic::internal {
 class BlockIndex {
  public:
   struct GridCoordinates {
-    std::size_t row;  // NOLINT
-    std::size_t col;  // NOLINT
+    std::size_t i1;  // NOLINT
+    std::size_t i2;  // NOLINT
 
     constexpr bool operator==(const GridCoordinates& other) const noexcept;
     constexpr bool operator!=(const GridCoordinates& other) const noexcept;
     constexpr bool operator<(const GridCoordinates& other) const noexcept;
   };
 
-  std::size_t _id{null_id};              // NOLINT
-  std::size_t _file_offset{};            // NOLINT
+  std::uint64_t _id{null_id};            // NOLINT
+  std::uint64_t _file_offset{};          // NOLINT
   std::size_t _compressed_size_bytes{};  // NOLINT
   GridCoordinates _coords{};             // NOLINT
 
-  static constexpr auto null_id = (std::numeric_limits<std::size_t>::max)();
+  static constexpr auto null_id = (std::numeric_limits<std::uint64_t>::max)();
 
   constexpr BlockIndex() = default;
   constexpr BlockIndex(std::size_t id_, std::size_t file_offset_,

--- a/src/hic/include/hictk/hic/index.hpp
+++ b/src/hic/include/hictk/hic/index.hpp
@@ -82,6 +82,7 @@ class Index {
         std::int32_t version_, std::size_t block_bin_count_, std::size_t block_column_count_,
         double sum_count_, BlkIdxBuffer blocks_);
 
+  [[nodiscard]] std::int32_t version() const noexcept;
   [[nodiscard]] MatrixUnit unit() const noexcept;
   [[nodiscard]] std::uint32_t resolution() const noexcept;
   [[nodiscard]] const Chromosome& chrom1() const noexcept;

--- a/src/hic/include/hictk/hic/index.hpp
+++ b/src/hic/include/hictk/hic/index.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <parallel_hashmap/phmap.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -55,11 +57,11 @@ class BlockIndex {
 // Map coordinates (bp) to block IDs
 class Index {
  public:
-  using BlkIdxBuffer = std::vector<BlockIndex>;
+  using BlkIdxBuffer = phmap::flat_hash_set<BlockIndex>;
   using iterator = BlkIdxBuffer::const_iterator;
   using const_iterator = BlkIdxBuffer::const_iterator;
 
-  using Overlap = BlkIdxBuffer;
+  using Overlap = std::vector<BlockIndex>;
 
  private:
   // map block_ids to file offsets

--- a/src/hic/include/hictk/hic/index.hpp
+++ b/src/hic/include/hictk/hic/index.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <parallel_hashmap/btree.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -54,24 +52,16 @@ class BlockIndex {
   constexpr bool operator!=(std::size_t id_) const noexcept;
 };
 
-struct BlockIndexCmp {
-  using is_transparent = void;
-
-  constexpr bool operator()(const BlockIndex& a, const BlockIndex& b) const noexcept;
-  constexpr bool operator()(const BlockIndex& a, std::size_t b_id) const noexcept;
-  constexpr bool operator()(std::size_t a_id, const BlockIndex& b) const noexcept;
-};
-
 // Map coordinates (bp) to block IDs
 class Index {
  public:
-  using BlockIndexMap = phmap::btree_set<BlockIndex, BlockIndexCmp>;
-  using iterator = BlockIndexMap::const_iterator;
-  using const_iterator = BlockIndexMap::const_iterator;
+  using BlkIdxBuffer = std::vector<BlockIndex>;
+  using iterator = BlkIdxBuffer::const_iterator;
+  using const_iterator = BlkIdxBuffer::const_iterator;
 
  private:
   // map block_ids to file offsets
-  BlockIndexMap _block_map{};
+  BlkIdxBuffer _buffer{};
   std::int32_t _version{};
   std::size_t _block_bin_count{};
   std::size_t _block_column_count{};  // columns of blocks per matrix?
@@ -88,7 +78,7 @@ class Index {
   Index() = default;
   Index(Chromosome chrom1_, Chromosome chrom2_, MatrixUnit unit_, std::uint32_t resolution_,
         std::int32_t version_, std::size_t block_bin_count_, std::size_t block_column_count_,
-        double sum_count_, BlockIndexMap blocks_);
+        double sum_count_, BlkIdxBuffer blocks_);
 
   [[nodiscard]] MatrixUnit unit() const noexcept;
   [[nodiscard]] std::uint32_t resolution() const noexcept;

--- a/src/hic/include/hictk/hic/index.hpp
+++ b/src/hic/include/hictk/hic/index.hpp
@@ -59,6 +59,8 @@ class Index {
   using iterator = BlkIdxBuffer::const_iterator;
   using const_iterator = BlkIdxBuffer::const_iterator;
 
+  using Overlap = BlkIdxBuffer;
+
  private:
   // map block_ids to file offsets
   BlkIdxBuffer _buffer{};
@@ -97,18 +99,17 @@ class Index {
   [[nodiscard]] std::size_t size() const noexcept;
   [[nodiscard]] bool empty() const noexcept;
 
-  [[nodiscard]] auto find_overlaps(const Bin& bin1, const PixelCoordinates& coords2) const
-      -> std::pair<const_iterator, const_iterator>;
+  [[nodiscard]] auto find_overlaps(const PixelCoordinates& coords1,
+                                   const PixelCoordinates& coords2) const -> Overlap;
 
   [[nodiscard]] const BlockIndex& at(std::size_t row, std::size_t col) const;
 
  private:
   [[nodiscard]] auto generate_block_list(std::size_t bin1, std::size_t bin2, std::size_t bin3,
-                                         std::size_t bin4) const
-      -> std::pair<const_iterator, const_iterator>;
+                                         std::size_t bin4) const -> Overlap;
   [[nodiscard]] auto generate_block_list_intra_v9plus(std::size_t bin1, std::size_t bin2,
                                                       std::size_t bin3, std::size_t bin4) const
-      -> std::pair<const_iterator, const_iterator>;
+      -> Overlap;
 };
 
 }  // namespace hictk::hic::internal

--- a/src/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/hic/include/hictk/hic/pixel_selector.hpp
@@ -27,8 +27,7 @@ class PixelSelector {
 
   PixelCoordinates _coord1{};
   PixelCoordinates _coord2{};
-
-  bool _clear_cache_on_destruction{true};
+  std::shared_ptr<const internal::Index::Overlap> _block_idx{};
 
  public:
   template <typename N>
@@ -44,14 +43,6 @@ class PixelSelector {
                 std::shared_ptr<const internal::HiCFooter> footer_,
                 std::shared_ptr<internal::BlockCache> cache_, std::shared_ptr<const BinTable> bins_,
                 PixelCoordinates coord1_, PixelCoordinates coord2_) noexcept;
-
-  PixelSelector(const PixelSelector &other) = default;
-  PixelSelector(PixelSelector &&other) noexcept;
-
-  ~PixelSelector() noexcept;
-
-  [[nodiscard]] PixelSelector &operator=(const PixelSelector &other) = default;
-  [[nodiscard]] PixelSelector &operator=(PixelSelector &&other) noexcept;
 
   [[nodiscard]] bool operator==(const PixelSelector &other) const noexcept;
   [[nodiscard]] bool operator!=(const PixelSelector &other) const noexcept;
@@ -92,7 +83,6 @@ class PixelSelector {
   [[nodiscard]] double avg() const noexcept;
 
   [[nodiscard]] std::size_t estimate_optimal_cache_size(std::size_t num_samples = 500) const;
-  void evict_blocks_from_cache() const;
 
  private:
   [[nodiscard]] SerializedPixel transform_pixel(SerializedPixel pixel) const;
@@ -106,7 +96,7 @@ class PixelSelector {
     using BufferT = std::vector<ThinPixel<N>>;
     using BlockIdxBufferT = std::vector<internal::BlockIndex>;
 
-    std::uint64_t _bin1_id{};
+    internal::Index::Overlap::const_iterator _block_it{};
     mutable std::shared_ptr<BufferT> _buffer{};
     mutable std::size_t _buffer_i{};
 

--- a/src/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/hic/include/hictk/hic/pixel_selector.hpp
@@ -11,8 +11,8 @@
 #include <vector>
 
 #include "hictk/bin_table.hpp"
-#include "hictk/hic/block_cache.hpp"
 #include "hictk/hic/block_reader.hpp"
+#include "hictk/hic/cache.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/file_reader.hpp"
 #include "hictk/hic/index.hpp"
@@ -69,8 +69,8 @@ class PixelSelector {
   [[nodiscard]] const Chromosome &chrom1() const noexcept;
   [[nodiscard]] const Chromosome &chrom2() const noexcept;
 
-  [[nodiscard]] const std::vector<double> &chrom1_norm() const noexcept;
-  [[nodiscard]] const std::vector<double> &chrom2_norm() const noexcept;
+  [[nodiscard]] const balancing::Weights &weights1() const noexcept;
+  [[nodiscard]] const balancing::Weights &weights2() const noexcept;
 
   [[nodiscard]] const BinTable &bins() const noexcept;
   [[nodiscard]] const internal::HiCFooterMetadata &metadata() const noexcept;
@@ -82,6 +82,7 @@ class PixelSelector {
   [[nodiscard]] double avg() const noexcept;
 
   [[nodiscard]] std::size_t estimate_optimal_cache_size(std::size_t num_samples = 500) const;
+  void clear_cache() const;
 
  private:
   [[nodiscard]] SerializedPixel transform_pixel(SerializedPixel pixel) const;
@@ -185,6 +186,7 @@ class PixelSelectorAll {
     using SelectorQueue = std::queue<const PixelSelector *>;
     using ItPQueue = std::priority_queue<Pair, std::vector<Pair>, std::greater<>>;
     std::shared_ptr<SelectorQueue> _selectors{};
+    std::shared_ptr<SelectorQueue> _active_selectors{};
     std::shared_ptr<ItPQueue> _its{};
 
     std::uint32_t _chrom1_id{};

--- a/src/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/hic/include/hictk/hic/pixel_selector.hpp
@@ -27,7 +27,6 @@ class PixelSelector {
 
   PixelCoordinates _coord1{};
   PixelCoordinates _coord2{};
-  std::shared_ptr<const internal::Index::Overlap> _block_idx{};
 
  public:
   template <typename N>
@@ -96,6 +95,7 @@ class PixelSelector {
     using BufferT = std::vector<ThinPixel<N>>;
     using BlockIdxBufferT = std::vector<internal::BlockIndex>;
 
+    std::shared_ptr<const internal::Index::Overlap> _block_idx{};
     internal::Index::Overlap::const_iterator _block_it{};
     mutable std::shared_ptr<BufferT> _buffer{};
     mutable std::size_t _buffer_i{};

--- a/src/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/hic/include/hictk/hic/pixel_selector.hpp
@@ -91,14 +91,14 @@ class PixelSelector {
   class iterator {
     static_assert(std::is_arithmetic_v<N>);
     friend PixelSelector;
-    const PixelSelector *_sel{};
     using BufferT = std::vector<ThinPixel<N>>;
-    using BlockIdxBufferT = std::vector<internal::BlockIndex>;
 
+    const PixelSelector *_sel{};
     std::shared_ptr<const internal::Index::Overlap> _block_idx{};
     internal::Index::Overlap::const_iterator _block_it{};
     mutable std::shared_ptr<BufferT> _buffer{};
     mutable std::size_t _buffer_i{};
+    std::uint32_t _bin1_id{};
 
    public:
     using difference_type = std::ptrdiff_t;
@@ -134,7 +134,11 @@ class PixelSelector {
     [[nodiscard]] std::uint64_t bin1_id() const noexcept;
     [[nodiscard]] std::uint64_t bin2_id() const noexcept;
 
+    [[nodiscard]] std::uint32_t compute_chunk_size() const noexcept;
+    [[nodiscard]] std::vector<internal::BlockIndex> find_blocks_overlapping_next_chunk(
+        std::size_t num_bins);
     void read_next_chunk();
+    void read_next_chunk_v9_intra();
   };
 };
 

--- a/src/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/hic/include/hictk/hic/pixel_selector.hpp
@@ -46,12 +46,12 @@ class PixelSelector {
                 PixelCoordinates coord1_, PixelCoordinates coord2_) noexcept;
 
   PixelSelector(const PixelSelector &other) = default;
-  PixelSelector(PixelSelector &&other) noexcept ;
+  PixelSelector(PixelSelector &&other) noexcept;
 
   ~PixelSelector() noexcept;
 
-  [[nodiscard]] PixelSelector& operator=(const PixelSelector &other) = default;
-  [[nodiscard]] PixelSelector& operator=(PixelSelector &&other);
+  [[nodiscard]] PixelSelector &operator=(const PixelSelector &other) = default;
+  [[nodiscard]] PixelSelector &operator=(PixelSelector &&other) noexcept;
 
   [[nodiscard]] bool operator==(const PixelSelector &other) const noexcept;
   [[nodiscard]] bool operator!=(const PixelSelector &other) const noexcept;
@@ -107,7 +107,6 @@ class PixelSelector {
     using BlockIdxBufferT = std::vector<internal::BlockIndex>;
 
     std::uint64_t _bin1_id{};
-    mutable std::shared_ptr<BlockIdxBufferT> _block_idx_buffer{};
     mutable std::shared_ptr<BufferT> _buffer{};
     mutable std::size_t _buffer_i{};
 
@@ -146,9 +145,6 @@ class PixelSelector {
     [[nodiscard]] std::uint64_t bin2_id() const noexcept;
 
     void read_next_chunk();
-    [[nodiscard]] const std::vector<internal::BlockIndex> &find_blocks_overlapping_next_chunk(
-        std::size_t num_bins);
-    [[nodiscard]] std::size_t compute_chunk_size(double fraction = 0.0005) const noexcept;
   };
 };
 

--- a/src/hic/index_impl.hpp
+++ b/src/hic/index_impl.hpp
@@ -22,7 +22,7 @@ namespace hictk::hic::internal {
 
 constexpr bool BlockIndex::GridCoordinates::operator==(
     const BlockIndex::GridCoordinates &other) const noexcept {
-  return row == other.row && col == other.col;
+  return i1 == other.i1 && i2 == other.i2;
 }
 
 constexpr bool BlockIndex::GridCoordinates::operator!=(
@@ -32,10 +32,10 @@ constexpr bool BlockIndex::GridCoordinates::operator!=(
 
 constexpr bool BlockIndex::GridCoordinates::operator<(
     const BlockIndex::GridCoordinates &other) const noexcept {
-  if (row == other.row) {
-    return col < other.col;
+  if (i1 == other.i1) {
+    return i2 < other.i2;
   }
-  return row < other.row;
+  return i1 < other.i1;
 }
 
 constexpr BlockIndex::BlockIndex(std::size_t id_, std::size_t file_offset_,
@@ -171,8 +171,13 @@ inline auto Index::generate_block_list(std::size_t bin1, std::size_t bin2, std::
       }
     }
   }
+
+  // Sort first by row, then by column
   std::sort(buffer.begin(), buffer.end(), [](const BlockIndex &b1, const BlockIndex &b2) {
-    return b1.coords().row < b2.coords().row;
+    if (b1.coords().i1 != b2.coords().i1) {
+      return b1.coords().i1 < b2.coords().i1;
+    }
+    return b1.coords().i2 < b2.coords().i2;
   });
   return buffer;
 }
@@ -217,10 +222,14 @@ inline auto Index::generate_block_list_intra_v9plus(std::size_t bin1, std::size_
       }
     }
   }
+
+  // Sort first by padding (ascending) then by depth (descending)
   std::sort(buffer.begin(), buffer.end(), [](const BlockIndex &b1, const BlockIndex &b2) {
-    return b1.coords().col < b2.coords().col;
+    if (b1.coords().i1 != b2.coords().i1) {
+      return b1.coords().i1 < b2.coords().i1;
+    }
+    return b1.coords().i2 > b2.coords().i2;
   });
-  std::unique(buffer.begin(), buffer.end());
   return buffer;
 }
 

--- a/src/hic/index_impl.hpp
+++ b/src/hic/index_impl.hpp
@@ -84,9 +84,7 @@ inline Index::Index(Chromosome chrom1_, Chromosome chrom2_, MatrixUnit unit_,
       _unit(unit_),
       _resolution(resolution_),
       _chrom1(std::move(chrom1_)),
-      _chrom2(std::move(chrom2_)) {
-  std::sort(_buffer.begin(), _buffer.end());
-}
+      _chrom2(std::move(chrom2_)) {}
 
 inline std::int32_t Index::version() const noexcept { return _version; }
 inline MatrixUnit Index::unit() const noexcept { return _unit; }
@@ -153,21 +151,13 @@ inline auto Index::generate_block_list(std::size_t bin1, std::size_t bin2, std::
   const auto row1 = bin3 / _block_bin_count;
   const auto row2 = (bin4 + 1) / _block_bin_count;
 
-  const auto first_id = (row1 * block_column_count()) + col1;
-  const auto last_id = (row2 * block_column_count()) + col2;
-
-  auto it1 = std::lower_bound(_buffer.begin(), _buffer.end(),
-                              BlockIndex{first_id, 0, 0, _block_column_count});
-  auto it2 = std::upper_bound(it1, _buffer.end(), BlockIndex{last_id, 0, 0, _block_column_count});
-
   Overlap buffer{};
   for (auto row = row1; row <= row2; ++row) {
     for (auto col = col1; col <= col2; ++col) {
       const auto block_id = (row * block_column_count()) + col;
-      const auto match =
-          std::equal_range(it1, it2, BlockIndex{block_id, 0, 0, _block_column_count});
-      if (match.first != match.second) {
-        buffer.emplace_back(*match.first);
+      const auto match = _buffer.find(BlockIndex{block_id, 0, 0, _block_column_count});
+      if (match != _buffer.end()) {
+        buffer.emplace_back(*match);
       }
     }
   }
@@ -204,21 +194,13 @@ inline auto Index::generate_block_list_intra_v9plus(std::size_t bin1, std::size_
 
   const auto furtherDepth = (std::max)(translatedNearerDepth, translatedFurtherDepth) + 1;
 
-  const auto first_block = (nearerDepth * block_column_count()) + translatedLowerPAD;
-  const auto last_block = (furtherDepth * block_column_count()) + translatedHigherPAD;
-
-  auto it1 = std::lower_bound(_buffer.begin(), _buffer.end(),
-                              BlockIndex{first_block, 0, 0, _block_column_count});
-  auto it2 =
-      std::upper_bound(it1, _buffer.end(), BlockIndex{last_block, 0, 0, _block_column_count});
-
   Overlap buffer{};
   for (auto pad = translatedLowerPAD; pad <= translatedHigherPAD; ++pad) {
     for (auto depth = nearerDepth; depth <= furtherDepth; ++depth) {
       const auto block_id = (depth * block_column_count()) + pad;
-      const auto match = std::equal_range(it1, it2, BlockIndex{block_id, 0, 0, _block_bin_count});
-      if (match.first != match.second) {
-        buffer.emplace_back(*match.first);
+      const auto match = _buffer.find(BlockIndex{block_id, 0, 0, _block_column_count});
+      if (match != _buffer.end()) {
+        buffer.emplace_back(*match);
       }
     }
   }

--- a/src/hic/index_impl.hpp
+++ b/src/hic/index_impl.hpp
@@ -125,7 +125,6 @@ inline auto Index::find_overlaps(const Bin &bin1, const PixelCoordinates &coords
     return std::make_pair(this->end(), this->end());
   }
 
-  assert(bin1.chrom() == _chrom1 || bin1.chrom() == _chrom2);
   assert(coords2.bin1.chrom() == _chrom1 || coords2.bin1.chrom() == _chrom2);
 
   auto bin1_id = bin1.rel_id();

--- a/src/hic/pixel_selector_impl.hpp
+++ b/src/hic/pixel_selector_impl.hpp
@@ -407,8 +407,7 @@ inline void PixelSelector::iterator<N>::read_next_chunk() {
   _buffer->clear();
   _buffer_i = 0;
 
-  auto [first_blki, last_blki] = _sel->_reader.index().find_overlaps(
-      bins().at_hint(_bin1_id, coord1().bin1.chrom()), coord2());
+  auto [first_blki, last_blki] = _sel->_reader.index().find_overlaps(bins().at(_bin1_id), coord2());
   if (first_blki == last_blki) {
     _bin1_id++;
     return;

--- a/src/hic/pixel_selector_impl.hpp
+++ b/src/hic/pixel_selector_impl.hpp
@@ -378,7 +378,7 @@ PixelSelector::iterator<N>::find_blocks_overlapping_next_chunk(std::size_t num_b
   const auto bin_size = bins().bin_size();
 
   const auto end_pos = coord1().bin2.start();
-  const auto pos1 = (std::min)(end_pos, static_cast<std::uint32_t>(_bin1_id) * bins().bin_size());
+  const auto pos1 = (std::min)(end_pos, _bin1_id * bins().bin_size());
   const auto pos2 = (std::min)(end_pos, pos1 + static_cast<std::uint32_t>((num_bins * bin_size)));
 
   const auto coord1_ = PixelCoordinates(bins().at(coord1().bin1.chrom(), pos1),

--- a/src/hic/pixel_selector_impl.hpp
+++ b/src/hic/pixel_selector_impl.hpp
@@ -209,17 +209,14 @@ inline std::size_t PixelSelector::estimate_optimal_cache_size(std::size_t num_sa
   std::size_t max_block_size = 0;
 
   std::vector<std::size_t> block_sizes{};
-  std::size_t samples = 0;
-  // index is backed by a hashmap, so iteration should be somewhat random
-  for (const auto &idx : _reader.index()) {
-    auto blk = _reader.read(chrom1(), chrom2(), idx);
+  std::vector<internal::BlockIndex> blocks(std::min(_reader.index().size(), num_samples));
+  std::sample(_reader.index().begin(), _reader.index().end(), blocks.begin(), blocks.size(),
+              rand_eng);
+  for (const auto &blki : blocks) {
+    auto blk = _reader.read(chrom1(), chrom2(), blki);
     if (blk) {
-      samples++;
       max_block_size = (std::max)(blk->size(), max_block_size);
       _reader.evict(*blk);
-    }
-    if (samples == num_samples) {
-      break;
     }
   }
 

--- a/src/hic/weight_cache_impl.hpp
+++ b/src/hic/weight_cache_impl.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+#include "hictk/balancing/weights.hpp"
+#include "hictk/chromosome.hpp"
+#include "hictk/hic/common.hpp"
+
+namespace hictk::hic::internal {
+
+inline auto WeightCache::find_or_emplace(std::uint32_t chrom_id, NormalizationMethod norm)
+    -> Value {
+  auto key = std::make_pair(chrom_id, norm);
+  auto it = _weights.find(key);
+  if (it != _weights.end()) {
+    return it->second;
+  }
+
+  return _weights.emplace(key, std::make_shared<balancing::Weights>()).first->second;
+}
+
+inline auto WeightCache::find_or_emplace(const Chromosome &chrom, NormalizationMethod norm)
+    -> Value {
+  return find_or_emplace(chrom.id(), norm);
+}
+
+inline void WeightCache::clear() noexcept { _weights.clear(); }
+inline std::size_t WeightCache::size() const noexcept { return _weights.size(); }
+
+}  // namespace hictk::hic::internal

--- a/src/hictk/cli/cli.cpp
+++ b/src/hictk/cli/cli.cpp
@@ -133,9 +133,9 @@ void Cli::transform_args() {
     case dump:  // NOLINT
       this->transform_args_dump_subcommand();
       break;
-    case load:      // NOLINT
+    case load:  // NOLINT
       [[fallthrough]];
-    case merge:     // NOLINT
+    case merge:  // NOLINT
       [[fallthrough]];
     case validate:  // NOLINT
       break;

--- a/src/hictk/cli/cli_validate.cpp
+++ b/src/hictk/cli/cli_validate.cpp
@@ -2,7 +2,6 @@
 // Created by roby on 7/13/23.
 //
 
-
 #include <fmt/format.h>
 #include <fmt/std.h>
 
@@ -49,4 +48,4 @@ void Cli::make_validate_subcommand() {
 
   this->_config = std::monostate{};
 }
-}
+}  // namespace hictk::tools

--- a/src/hictk/convert/hic_to_cool.cpp
+++ b/src/hictk/convert/hic_to_cool.cpp
@@ -56,15 +56,15 @@ static std::vector<double> read_weights(hic::HiCFile& f, const BinTable& bins,
     }
     const auto expected_length = (chrom.size() + bins.bin_size() - 1) / bins.bin_size();
     try {
-      const auto weights_ = f.fetch(chrom.name(), norm).chrom1_norm();
-      if (weights_.size() != expected_length) {
+      const auto weights_ = f.fetch(chrom.name(), norm).weights1();
+      if (weights_().size() != expected_length) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("{} normalization vector for {} appears to be corrupted: "
                                    "expected {} values, found {}"),
-                        norm, chrom.name(), expected_length, weights_.size()));
+                        norm, chrom.name(), expected_length, weights_().size()));
       }
 
-      weights.insert(weights.end(), weights_.begin(), weights_.end());
+      weights.insert(weights.end(), weights_().begin(), weights_().end());
     } catch (const std::exception& e) {
       if (!missing_norm_or_interactions(e, norm)) {
         throw;

--- a/src/hictk/convert/hic_to_cool.cpp
+++ b/src/hictk/convert/hic_to_cool.cpp
@@ -45,6 +45,27 @@ bool check_if_norm_exists(hic::HiCFile& f, hic::NormalizationMethod norm) {
   });
 }
 
+static std::vector<double> read_weights_or_throw(hic::HiCFile& f, hic::NormalizationMethod norm,
+                                                 const Chromosome& chrom,
+                                                 std::size_t expected_length) {
+  std::vector<double> weights_{};
+  try {
+    auto weights = f.fetch(chrom.name(), norm).weights1();
+    if (!!weights && weights().size() != expected_length) {
+      throw std::runtime_error(
+          fmt::format(FMT_STRING("{} normalization vector for {} appears to be corrupted: "
+                                 "expected {} values, found {}"),
+                      norm, chrom.name(), expected_length, weights().size()));
+    }
+    weights_ = weights();
+  } catch (const std::exception& e) {
+    if (!missing_norm_or_interactions(e, norm)) {
+      throw;
+    }
+  }
+  return weights_;
+}
+
 static std::vector<double> read_weights(hic::HiCFile& f, const BinTable& bins,
                                         hic::NormalizationMethod norm) {
   std::vector<double> weights{};
@@ -55,23 +76,12 @@ static std::vector<double> read_weights(hic::HiCFile& f, const BinTable& bins,
       continue;
     }
     const auto expected_length = (chrom.size() + bins.bin_size() - 1) / bins.bin_size();
-    try {
-      const auto weights_ = f.fetch(chrom.name(), norm).weights1();
-      if (weights_().size() != expected_length) {
-        throw std::runtime_error(
-            fmt::format(FMT_STRING("{} normalization vector for {} appears to be corrupted: "
-                                   "expected {} values, found {}"),
-                        norm, chrom.name(), expected_length, weights_().size()));
-      }
-
-      weights.insert(weights.end(), weights_().begin(), weights_().end());
-    } catch (const std::exception& e) {
-      if (!missing_norm_or_interactions(e, norm)) {
-        throw;
-      }
-      weights.resize(weights.size() + expected_length, std::numeric_limits<double>::quiet_NaN());
+    auto chrom_weights = read_weights_or_throw(f, norm, chrom, expected_length);
+    if (chrom_weights.empty()) {
+      chrom_weights.resize(expected_length, std::numeric_limits<double>::quiet_NaN());
       ++missing_norms;
     }
+    weights.insert(weights.end(), chrom_weights.begin(), chrom_weights.end());
   }
   if (missing_norms == f.chromosomes().size() - 1) {
     spdlog::warn(FMT_STRING("[{}] {} normalization vector is missing. Filling "

--- a/src/hictk/zoomify/zoomify.cpp
+++ b/src/hictk/zoomify/zoomify.cpp
@@ -68,7 +68,7 @@ int zoomify_subcmd(const ZoomifyConfig& c) {
                                               clr1.bins_ptr(), clr2.bin_size() / clr1.bin_size());
 
       const auto update_frequency =
-          std::max(std::size_t(1'000'000), static_cast<std::size_t>(*clr1.attributes().nnz / 100));
+          std::max(std::size_t(1'000'000), (clr1.dataset("pixels/bin1_id").size() / 100));
 
       auto first = sel2.begin();
       auto last = sel2.end();

--- a/test/scripts/hictk_convert_cool2hic.sh
+++ b/test/scripts/hictk_convert_cool2hic.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##################################"
+echo "#### hictk convert (cool2hic) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_convert_cool2hic.sh
+++ b/test/scripts/hictk_convert_cool2hic.sh
@@ -67,7 +67,7 @@ juicer_tools_jar="$2"
 data_dir="$(readlink_py "$(dirname "$0")/../data/")"
 script_dir="$(readlink_py "$(dirname "$0")")"
 
-ref_cool="$data_dir/cooler/multires_cooler_test_file.mcool"
+ref_cool="$data_dir/integration_tests/4DNFIZ1ZVXC8.mcool"
 
 export PATH="$PATH:$script_dir"
 
@@ -78,7 +78,7 @@ fi
 outdir="$(mktemp -d -t hictk-tmp-XXXXXXXXXX)"
 trap 'rm -rf -- "$outdir"' EXIT
 
-resolutions=(100000 6400000)
+resolutions=(100000 2500000)
 
 "$hictk_bin" convert \
              "$ref_cool" \

--- a/test/scripts/hictk_convert_hic2cool.sh
+++ b/test/scripts/hictk_convert_hic2cool.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##################################"
+echo "#### hictk convert (hic2cool) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_balanced.sh
+++ b/test/scripts/hictk_dump_balanced.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "###############################"
+echo "#### hictk dump (balanced) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_bins.sh
+++ b/test/scripts/hictk_dump_bins.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "###########################"
+echo "#### hictk dump (bins) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_chroms.sh
+++ b/test/scripts/hictk_dump_chroms.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "#############################"
+echo "#### hictk dump (chroms) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_cis.sh
+++ b/test/scripts/hictk_dump_cis.sh
@@ -60,7 +60,8 @@ data_dir="$(readlink_py "$(dirname "$0")/../data/")"
 script_dir="$(readlink_py "$(dirname "$0")")"
 
 ref_cooler="$data_dir/integration_tests/4DNFIZ1ZVXC8.mcool"
-ref_hic="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic8="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic9="$data_dir/hic/4DNFIZ1ZVXC8.hic9"
 
 export PATH="$PATH:$script_dir"
 
@@ -77,7 +78,7 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-if ! check_files_exist "$ref_cooler"; then
+if ! check_files_exist "$ref_cooler" "$ref_hic8" "$ref_hic9"; then
   exit 1
 fi
 
@@ -86,13 +87,18 @@ trap 'rm -rf -- "$outdir"' EXIT
 
 cooler dump --join "$ref_cooler::/resolutions/100000" -r chr2L > "$outdir/expected.pixels"
 "$hictk_bin" dump "$ref_cooler::/resolutions/100000" -r chr2L > "$outdir/out.cooler.pixels"
-"$hictk_bin" dump --resolution 100000 "$ref_hic" -r chr2L > "$outdir/out.hic.pixels"
+"$hictk_bin" dump --resolution 100000 "$ref_hic8" -r chr2L > "$outdir/out.hic8.pixels"
+"$hictk_bin" dump --resolution 100000 "$ref_hic9" -r chr2L > "$outdir/out.hic9.pixels"
 
 if ! compare_files "$outdir/expected.pixels" "$outdir/out.cooler.pixels"; then
   status=1
 fi
 
-if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic.pixels"; then
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic8.pixels"; then
+  status=1
+fi
+
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic9.pixels"; then
   status=1
 fi
 

--- a/test/scripts/hictk_dump_cis.sh
+++ b/test/scripts/hictk_dump_cis.sh
@@ -8,6 +8,10 @@ set -e
 set -o pipefail
 set -u
 
+
+echo "##########################"
+echo "#### hictk dump (cis) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_gw.sh
+++ b/test/scripts/hictk_dump_gw.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##################################"
+echo "#### hictk dump (genome-wide) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_gw.sh
+++ b/test/scripts/hictk_dump_gw.sh
@@ -59,7 +59,8 @@ data_dir="$(readlink_py "$(dirname "$0")/../data/")"
 script_dir="$(readlink_py "$(dirname "$0")")"
 
 ref_cooler="$data_dir/integration_tests/4DNFIZ1ZVXC8.mcool"
-ref_hic="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic8="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic9="$data_dir/hic/4DNFIZ1ZVXC8.hic9"
 
 export PATH="$PATH:$script_dir"
 
@@ -76,7 +77,7 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-if ! check_files_exist "$ref_cooler"; then
+if ! check_files_exist "$ref_cooler" "$ref_hic8" "$ref_hic9"; then
   exit 1
 fi
 
@@ -85,13 +86,18 @@ trap 'rm -rf -- "$outdir"' EXIT
 
 cooler dump --join "$ref_cooler::/resolutions/1000000" > "$outdir/expected.pixels"
 "$hictk_bin" dump "$ref_cooler::/resolutions/1000000" > "$outdir/out.cooler.pixels"
-"$hictk_bin" dump --resolution 1000000 "$ref_hic" > "$outdir/out.hic.pixels"
+"$hictk_bin" dump --resolution 1000000 "$ref_hic8" > "$outdir/out.hic8.pixels"
+"$hictk_bin" dump --resolution 1000000 "$ref_hic9" > "$outdir/out.hic9.pixels"
 
 if ! compare_files "$outdir/expected.pixels" "$outdir/out.cooler.pixels"; then
   status=1
 fi
 
-if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic.pixels"; then
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic8.pixels"; then
+  status=1
+fi
+
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic9.pixels"; then
   status=1
 fi
 

--- a/test/scripts/hictk_dump_trans.sh
+++ b/test/scripts/hictk_dump_trans.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "############################"
+echo "#### hictk dump (trans) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_dump_trans.sh
+++ b/test/scripts/hictk_dump_trans.sh
@@ -59,7 +59,8 @@ data_dir="$(readlink_py "$(dirname "$0")/../data/")"
 script_dir="$(readlink_py "$(dirname "$0")")"
 
 ref_cooler="$data_dir/integration_tests/4DNFIZ1ZVXC8.mcool"
-ref_hic="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic8="$data_dir/hic/4DNFIZ1ZVXC8.hic8"
+ref_hic9="$data_dir/hic/4DNFIZ1ZVXC8.hic9"
 
 export PATH="$PATH:$script_dir"
 
@@ -76,7 +77,7 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-if ! check_files_exist "$ref_cooler"; then
+if ! check_files_exist "$ref_cooler" "$ref_hic8" "$ref_hic9"; then
   exit 1
 fi
 
@@ -85,13 +86,18 @@ trap 'rm -rf -- "$outdir"' EXIT
 
 cooler dump --join "$ref_cooler::/resolutions/100000" --range chr2L --range2 chrX > "$outdir/expected.pixels"
 "$hictk_bin" dump "$ref_cooler::/resolutions/100000" --range chr2L --range2 chrX > "$outdir/out.cooler.pixels"
-"$hictk_bin" dump --resolution 100000 "$ref_hic" --range chr2L --range2 chrX > "$outdir/out.hic.pixels"
+"$hictk_bin" dump --resolution 100000 "$ref_hic8" --range chr2L --range2 chrX > "$outdir/out.hic8.pixels"
+"$hictk_bin" dump --resolution 100000 "$ref_hic9" --range chr2L --range2 chrX > "$outdir/out.hic9.pixels"
 
 if ! compare_files "$outdir/expected.pixels" "$outdir/out.cooler.pixels"; then
   status=1
 fi
 
-if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic.pixels"; then
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic8.pixels"; then
+  status=1
+fi
+
+if ! compare_files "$outdir/expected.pixels" "$outdir/out.hic9.pixels"; then
   status=1
 fi
 

--- a/test/scripts/hictk_load_4dn.sh
+++ b/test/scripts/hictk_load_4dn.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##########################"
+echo "#### hictk load (4DN) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_load_bg2.sh
+++ b/test/scripts/hictk_load_bg2.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##########################"
+echo "#### hictk load (BG2) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_load_coo.sh
+++ b/test/scripts/hictk_load_coo.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "##########################"
+echo "#### hictk load (COO) ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_validate.sh
+++ b/test/scripts/hictk_validate.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "########################"
+echo "#### hictk validate ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/scripts/hictk_zoomify.sh
+++ b/test/scripts/hictk_zoomify.sh
@@ -8,6 +8,9 @@ set -e
 set -o pipefail
 set -u
 
+echo "#######################"
+echo "#### hictk zoomify ####"
+
 # readlink -f is not available on macos...
 function readlink_py {
   set -eu

--- a/test/units/hic/file_reader_test.cpp
+++ b/test/units/hic/file_reader_test.cpp
@@ -89,8 +89,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340697);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     CHECK(f.expectedValues().empty());
   }
 
@@ -103,8 +103,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11389664);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -117,8 +117,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11389664);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -131,8 +131,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11389664);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -145,8 +145,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11389664);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -159,8 +159,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340697);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     REQUIRE(f.expectedValues().size() == 6415);
 
     for (std::size_t i = 0; i < expected1.size(); ++i) {
@@ -179,8 +179,8 @@ TEST_CASE("HiC: read footer (v8)", "[hic][v8][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340697);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     REQUIRE(f.expectedValues().size() == 6415);
 
     for (std::size_t i = 0; i < expected1.size(); ++i) {
@@ -213,8 +213,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340696);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     CHECK(f.expectedValues().empty());
   }
 
@@ -227,8 +227,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11625116);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -241,8 +241,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11625116);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -255,8 +255,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 11625116);
-    CHECK(f.c1Norm().size() == 4703);
-    CHECK(f.c2Norm().size() == 5058);
+    CHECK(f.weights1()().size() == 4703);
+    CHECK(f.weights2()().size() == 5058);
     CHECK(f.expectedValues().empty());
   }
 
@@ -269,8 +269,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340696);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     REQUIRE(f.expectedValues().size() == 6415);
 
     for (std::size_t i = 0; i < expected1.size(); ++i) {
@@ -289,8 +289,8 @@ TEST_CASE("HiC: read footer (v9)", "[hic][v9][short]") {
     CHECK(f.unit() == MatrixUnit::BP);
     CHECK(f.resolution() == 5000);
     CHECK(f.fileOffset() == 340696);
-    CHECK(f.c1Norm().empty());
-    CHECK(f.c2Norm().empty());
+    CHECK(!f.weights1());
+    CHECK(!f.weights2());
     REQUIRE(f.expectedValues().size() == 6415);
 
     for (std::size_t i = 0; i < expected1.size(); ++i) {


### PR DESCRIPTION
- Optimize chunk size used during iteration
- Be more aggressive when evicting interaction blocks from block cache
- Introduce cache for weights (greatly reduces memory usage when iterating through the entire genome at very high resolutions)