### PR TITLE
Fix performance regression

### DIFF
--- a/src/cooler/dataset_accessors_impl.hpp
+++ b/src/cooler/dataset_accessors_impl.hpp
@@ -34,9 +34,21 @@ inline std::string Dataset::uri() const {
   return fmt::format(FMT_STRING("{}::{}"), file_name(), hdf5_path());
 }
 
-inline std::size_t Dataset::size() const { return _dataset.getElementCount(); }
+inline std::size_t Dataset::size() const { return _dataset_size; }
 
 inline bool Dataset::empty() const { return size() == 0; }
+
+inline std::size_t Dataset::get_chunk_size() const noexcept { return _chunk_size; }
+
+inline std::size_t Dataset::get_chunk_size(const HighFive::DataSet &dset) {
+  [[maybe_unused]] HighFive::SilenceHDF5 silencer{};  // NOLINT
+  hsize_t size{};
+  const auto dims = H5Pget_chunk(dset.getCreatePropertyList().getId(), 1, &size);
+  if (dims != 1) {
+    return dset.getElementCount();
+  }
+  return size;
+}
 
 inline HighFive::DataSet Dataset::get() { return _dataset; }
 inline const HighFive::DataSet &Dataset::get() const { return _dataset; }

--- a/src/cooler/dataset_read_impl.hpp
+++ b/src/cooler/dataset_read_impl.hpp
@@ -25,9 +25,8 @@ inline std::size_t Dataset::read(std::vector<N> &buff, std::size_t num, std::siz
   }
 
   buff.resize(num);
-  select(offset, num).read(buff.data(), HighFive::create_datatype<N>());
 
-  return offset + num;
+  return read(buff.data(), buff.size(), offset);
 }
 
 inline std::size_t Dataset::read(std::vector<std::string> &buff, std::size_t num,
@@ -124,8 +123,7 @@ inline std::size_t Dataset::read(N &buff, std::size_t offset) const {
     throw_out_of_range_excp(offset);
   }
 
-  select(offset, 1).read(&buff, HighFive::create_datatype<N>());
-  return offset + 1;
+  return read(&buff, 1, offset);
 }
 
 inline std::size_t Dataset::read(std::string &buff, std::size_t offset) const {
@@ -225,6 +223,12 @@ inline void Dataset::read_attribute(std::string_view key, std::vector<T> &buff) 
 inline auto Dataset::read_attribute(std::string_view key, bool missing_ok) const
     -> Attribute::AttributeVar {
   return Attribute::read(_dataset, key, missing_ok);
+}
+
+template <typename T>
+inline std::size_t Dataset::read(T *buffer, std::size_t buff_size, std::size_t offset) const {
+  select(offset, buff_size).read(buffer, HighFive::create_datatype<T>());
+  return offset + buff_size;
 }
 
 }  // namespace hictk::cooler

--- a/src/cooler/dataset_write_impl.hpp
+++ b/src/cooler/dataset_write_impl.hpp
@@ -53,7 +53,7 @@ inline std::size_t Dataset::write(const std::vector<std::string> &buff, std::siz
   auto dspace = select(offset, buff.size());
   dspace.write_raw(strbuff.data(), dspace.getDataType());
 
-  return offset + buff.size();
+  return size();
 }
 
 template <typename N, typename>
@@ -72,7 +72,7 @@ inline std::size_t Dataset::write(const std::vector<N> &buff, std::size_t offset
   }
 
   select(offset, buff.size()).write(buff);
-  return offset + buff.size();
+  return size();
 }
 
 inline std::size_t Dataset::write(const VariantBuffer &vbuff, std::size_t offset,
@@ -139,7 +139,7 @@ inline std::size_t Dataset::write(N buff, std::size_t offset, bool allow_dataset
   }
 
   select(offset).write(buff);
-  return offset + 1;
+  return ++_dataset_size;
 }
 
 inline std::size_t Dataset::write(std::string buff, std::size_t offset, bool allow_dataset_resize) {
@@ -152,14 +152,14 @@ inline std::size_t Dataset::write(std::string buff, std::size_t offset, bool all
     }
   }
 
-  auto dspace = select(offset);
+  auto selector = select(offset);
 
-  const auto str_length = dspace.getDataType().getSize();
+  const auto str_length = selector.getDataType().getSize();
   buff.resize(str_length, '\0');
 
-  dspace.write_raw(buff.data(), dspace.getDataType());
+  selector.write_raw(buff.data(), selector.getDataType());
 
-  return offset + 1;
+  return ++_dataset_size;
 }
 
 inline std::size_t Dataset::write(const GenericVariant &vbuff, std::size_t offset,

--- a/src/cooler/file_read_impl.hpp
+++ b/src/cooler/file_read_impl.hpp
@@ -491,8 +491,8 @@ inline Index File::init_index(const Dataset &chrom_offset_dset, const Dataset &b
                       bin_offset_dset.hdf5_path(), bin_table->size() + 1, bin_offset_dset.size()));
     }
 
-    auto first = bin_offset_dset.begin<std::uint64_t>(64'000);
-    auto last = bin_offset_dset.end<std::uint64_t>(64'000);
+    auto first = bin_offset_dset.begin<std::uint64_t>();
+    auto last = bin_offset_dset.end<std::uint64_t>();
 
     assert(first != last);
     if (const auto offset = *first; offset != 0) {
@@ -534,8 +534,8 @@ inline bool File::read_index_chunk(const Chromosome &chrom) const {
 
     auto offset1 = chrom_offsets[chrom.id()];
     auto offset2 = chrom_offsets[chrom.id() + 1];
-    auto first = bin_offset_dset.begin<std::uint64_t>(64'000) + offset1;
-    auto last = bin_offset_dset.begin<std::uint64_t>(64'000) + offset2;
+    auto first = bin_offset_dset.begin<std::uint64_t>() + offset1;
+    auto last = bin_offset_dset.begin<std::uint64_t>() + offset2;
     _index->set(chrom, {first, last});
 
     try {


### PR DESCRIPTION
- Avoid calling expensive HDF5 methods when reading datasets
- Add seek method to Dataset::iterator to use instead of constructing new iterators
- Set Dataset::iterator chunk size based on HDF5 chunk size