### PR TITLE
Support reading hic v6 and v7

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: MIT
 
 [requires]
-boost/1.82.0
+boost/1.83.0
 cli11/2.3.2
 eigen/3.4.0
 fast_float/5.2.0
-fmt/10.0.0
+fmt/10.1.0
 hdf5/1.14.0
 highfive/2.7.1
 libdeflate/1.18

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,17 +3,17 @@
 # SPDX-License-Identifier: MIT
 
 [requires]
-boost/1.83.0
-cli11/2.3.2
-eigen/3.4.0
-fast_float/5.2.0
-fmt/10.1.0
-hdf5/1.14.0
-highfive/2.7.1
-libdeflate/1.18
-parallel-hashmap/1.3.11
-readerwriterqueue/1.0.6
-spdlog/1.12.0
+boost/1.83.0#f0c3932db7f65b606ed78357ecbdcbef
+cli11/2.3.2#1424b9b1d9e3682a7122f415b078b4d7
+eigen/3.4.0#2e192482a8acff96fe34766adca2b24c
+fast_float/5.2.0#9bf1a3fac625789f2b571d43efb8013b
+fmt/10.1.0#1fae165cded07416f64960a5b6140317
+hdf5/1.14.0#011206975dc4c5ca80dd612d3a34cab3
+highfive/2.7.1#a73bc6937c9add30c9d47a7a70a466eb
+libdeflate/1.18#3697b637656a9af04cabcbed50db9a7e
+parallel-hashmap/1.3.11#719aed501c271a34e2347a7731ab3bfb
+readerwriterqueue/1.0.6#aaa5ff6fac60c2aee591e9e51b063b83
+spdlog/1.12.0#248c215bc5f0718402fbf1de126ef847
 
 [generators]
 CMakeDeps

--- a/src/libhictk/hic/include/hictk/hic/block_reader.hpp
+++ b/src/libhictk/hic/include/hictk/hic/block_reader.hpp
@@ -58,6 +58,10 @@ class HiCBlockReader {
   [[nodiscard]] double sum() const noexcept;
   [[nodiscard]] double avg() const;
 
+  [[nodiscard]] std::shared_ptr<const InteractionBlock> read_v6(const Chromosome& chrom1,
+                                                                const Chromosome& chrom2,
+                                                                const BlockIndex& idx,
+                                                                bool cache_block = true);
   [[nodiscard]] std::shared_ptr<const InteractionBlock> read(const Chromosome& chrom1,
                                                              const Chromosome& chrom2,
                                                              const BlockIndex& idx,

--- a/src/libhictk/hic/include/hictk/hic/impl/file_reader_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_reader_impl.hpp
@@ -247,9 +247,9 @@ inline HiCHeader HiCFileReader::readHeader(filestream::FileStream &fs) {
   HiCHeader header{fs.url()};
 
   fs.read(header.version);
-  if (header.version < 8) {
+  if (header.version < 6) {
     throw std::runtime_error(fmt::format(
-        FMT_STRING(".hic version 7 and older are no longer supported. Found version {}"),
+        FMT_STRING(".hic version 5 and older are no longer supported. Found version {}"),
         header.version));
   }
   fs.read(header.masterIndexOffset);


### PR DESCRIPTION
hic v7 support was tested using the following file: https://www.encodeproject.org/files/ENCFF718AWL/

hic v6 support was not tested as I am unable to find a file this old (the oldest files I checked were from GSE63525).

I was also unable to acquire a copy of juicer_tools (or juicebox_tools/hic_tools) old enough to be able to generate hic v7 or v6.