### PR TITLE
Improve ICE balancing

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -16,7 +16,6 @@ parallel-hashmap/1.3.11#1e67f4855a3f7cdeb977cc472113baf7
 readerwriterqueue/1.0.6#aaa5ff6fac60c2aee591e9e51b063b83
 span-lite/0.10.3#1967d71abb32b314387c2ab9c558dd22
 spdlog/1.12.0#0e390a2f5c3e96671d0857bc734e4731
-xxhash/0.8.2#03fd1c9a839b3f9cdf5ea9742c312187
 zstd/1.5.5#b87dc3b185caa4b122979ac4ae8ef7e8
 
 [generators]
@@ -73,4 +72,3 @@ highfive*:with_eigen=False
 highfive*:with_opencv=False
 highfive*:with_xtensor=False
 spdlog*:header_only=True
-xxhash*:utility=False

--- a/src/libhictk/balancing/CMakeLists.txt
+++ b/src/libhictk/balancing/CMakeLists.txt
@@ -5,7 +5,6 @@
 find_package(bshoshany-thread-pool REQUIRED)
 find_package(phmap REQUIRED)
 find_package(span-lite REQUIRED)
-find_package(xxHash REQUIRED)
 find_package(zstd REQUIRED)
 
 add_library(balancing INTERFACE)
@@ -28,7 +27,6 @@ target_link_system_libraries(
   bshoshany-thread-pool::bshoshany-thread-pool
   nonstd::span-lite
   phmap
-  xxHash::xxhash
   "zstd::libzstd_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>")
 
 target_compile_definitions(balancing INTERFACE span_FEATURE_MAKE_SPAN=1)

--- a/src/libhictk/balancing/include/hictk/balancing/impl/sparse_matrix_impl.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/impl/sparse_matrix_impl.hpp
@@ -54,12 +54,12 @@ inline MargsVector& MargsVector::operator=(const MargsVector& other) {
 
 inline double MargsVector::operator[](std::size_t i) const noexcept {
   assert(i < size());
-  return static_cast<double>(_margsi[i].load()) / static_cast<double>(_cfx);
+  return decode(_margsi[i].load());
 }
 
 inline void MargsVector::add(std::size_t i, double n) noexcept {
   assert(i < size());
-  _margsi[i] += static_cast<N::value_type>(n * static_cast<double>(_cfx));
+  _margsi[i] += encode(n);
 }
 
 inline const std::vector<double>& MargsVector::operator()() const noexcept {
@@ -78,9 +78,9 @@ inline std::vector<double>& MargsVector::operator()() noexcept {
   return _margsd;
 }
 
-inline void MargsVector::fill(N::value_type value) noexcept {
+inline void MargsVector::fill(double value) noexcept {
   for (auto& n : _margsi) {
-    std::atomic_init(&n, value);
+    n = encode(value);
   }
 }
 
@@ -92,6 +92,14 @@ inline void MargsVector::resize(std::size_t size_) {
 
 inline std::size_t MargsVector::size() const noexcept { return _margsi.size(); }
 inline bool MargsVector::empty() const noexcept { return size() == 0; }
+
+inline auto MargsVector::encode(double n) const noexcept -> I {
+  return static_cast<I>(n * static_cast<double>(_cfx));
+}
+
+inline double MargsVector::decode(I n) const noexcept {
+  return static_cast<double>(n) / static_cast<double>(_cfx);
+}
 
 inline bool SparseMatrix::empty() const noexcept { return size() == 0; }
 inline std::size_t SparseMatrix::size() const noexcept { return _counts.size(); }

--- a/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
@@ -7,13 +7,13 @@
 #include <zstd.h>
 
 #include <BS_thread_pool.hpp>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <ios>
 #include <memory>
-#include <mutex>
 #include <nonstd/span.hpp>
 #include <string>
 #include <type_traits>
@@ -36,12 +36,15 @@ struct default_delete<ZSTD_DCtx_s> {
 namespace hictk::balancing {
 
 class MargsVector {
-  std::vector<double> _margs{};
-  mutable std::vector<std::mutex> _mtxes;
+  using N = std::atomic<std::uint64_t>;
+  std::vector<N> _margsi{};
+  mutable std::vector<double> _margsd{};
+  std::uint64_t _cfx{};
+  const static auto DEFAULT_DECIMAL_DIGITS = 6ULL;
 
  public:
-  MargsVector() = default;
-  explicit MargsVector(std::size_t size_);
+  MargsVector() = delete;
+  explicit MargsVector(std::size_t size_ = 0, std::size_t decimals = DEFAULT_DECIMAL_DIGITS);
 
   MargsVector(const MargsVector& other);
   MargsVector(MargsVector&& other) noexcept = default;
@@ -52,23 +55,16 @@ class MargsVector {
   MargsVector& operator=(MargsVector&& other) noexcept = default;
 
   [[nodiscard]] double operator[](std::size_t i) const noexcept;
-  [[nodiscard]] double& operator[](std::size_t i) noexcept;
   void add(std::size_t i, double n) noexcept;
 
   [[nodiscard]] const std::vector<double>& operator()() const noexcept;
   [[nodiscard]] std::vector<double>& operator()() noexcept;
 
-  void fill(double n = 0) noexcept;
+  void fill(N::value_type value = 0) noexcept;
   void resize(std::size_t size_);
 
   [[nodiscard]] std::size_t size() const noexcept;
   [[nodiscard]] bool empty() const noexcept;
-
- private:
-  static std::size_t compute_number_of_mutexes(std::size_t size) noexcept;
-  template <typename I, typename = std::enable_if_t<std::is_integral_v<I>>>
-  [[nodiscard]] static I next_pow2(I n) noexcept;
-  [[nodiscard]] std::size_t get_mutex_idx(std::size_t i) const noexcept;
 };
 
 class SparseMatrix {

--- a/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
@@ -36,11 +36,12 @@ struct default_delete<ZSTD_DCtx_s> {
 namespace hictk::balancing {
 
 class MargsVector {
-  using N = std::atomic<std::uint64_t>;
+  using I = std::uint64_t;
+  using N = std::atomic<I>;
   std::vector<N> _margsi{};
   mutable std::vector<double> _margsd{};
   std::uint64_t _cfx{};
-  const static auto DEFAULT_DECIMAL_DIGITS = 6ULL;
+  const static auto DEFAULT_DECIMAL_DIGITS = 9ULL;
 
  public:
   MargsVector() = delete;
@@ -60,11 +61,15 @@ class MargsVector {
   [[nodiscard]] const std::vector<double>& operator()() const noexcept;
   [[nodiscard]] std::vector<double>& operator()() noexcept;
 
-  void fill(N::value_type value = 0) noexcept;
+  void fill(double value = 0) noexcept;
   void resize(std::size_t size_);
 
   [[nodiscard]] std::size_t size() const noexcept;
   [[nodiscard]] bool empty() const noexcept;
+
+ private:
+  auto encode(double n) const noexcept -> I;
+  double decode(I n) const noexcept;
 };
 
 class SparseMatrix {

--- a/test/units/balancing/balancing_test.cpp
+++ b/test/units/balancing/balancing_test.cpp
@@ -50,14 +50,14 @@ namespace hictk::test::balancing {
 }
 
 static void compare_weights(const std::vector<double>& weights, const std::vector<double>& expected,
-                            double tol = 1.0e-6) {
+                            double tol = 1.0e-5) {
   REQUIRE(weights.size() == expected.size());
 
   for (std::size_t i = 0; i < weights.size(); ++i) {
     if (std::isnan(weights[i])) {
       CHECK(std::isnan(expected[i]));
     } else {
-      CHECK_THAT(weights[i], Catch::Matchers::WithinAbs(expected[i], tol));
+      CHECK_THAT(weights[i], Catch::Matchers::WithinRel(expected[i], tol));
     }
   }
 }


### PR DESCRIPTION
Make result of interaction balancing independent from the number of balancing threads

This is achieved by using fixed-precision arithmetic when computing the marginals using multiple threads.
Explicit synchronization is no longer necessary, as we can now use atomic ints instead of double + mutex.

The downside to this approach is that results are no longer identical to those of cooler.
However, practically speaking, hictk's and cooler's results are equivalent, as balancing tests show that the relative error is below 1.0e-5.

Switching to atomic operations also improved performance.
This is especially noticeable when balancing using --in-memory (~2.5x perf improvement).