### PR TITLE
Fix segfault when computing the expected value vector

### DIFF
--- a/src/libhictk/expected_values_aggregator/include/hictk/impl/expected_values_aggregator_impl.hpp
+++ b/src/libhictk/expected_values_aggregator/include/hictk/impl/expected_values_aggregator_impl.hpp
@@ -39,6 +39,7 @@ inline ExpectedValuesAggregator::ExpectedValuesAggregator(std::shared_ptr<const 
   const auto max_n_bins = max_length / bin_size;
   _possible_distances.resize(max_n_bins, 0.0);
   _actual_distances.resize(max_n_bins, 0.0);
+  _weights.resize(max_n_bins, 0.0);
 }
 
 template <typename N>
@@ -123,6 +124,10 @@ inline void ExpectedValuesAggregator::compute_density_cis() {
   // Re-implementation of the algorithm used by HiCTools:
   // https://github.com/aidenlab/HiCTools/blob/6b2fab8e78685deae199c33bbb167dcab1dbfbb3/src/hic/tools/utils/original/ExpectedValueCalculation.java#L184
 
+  if (_actual_distances.empty()) {
+    return;
+  }
+
   auto num_sum = _actual_distances.front();
   auto den_sum = _possible_distances.front();
   std::size_t bound1 = 0;
@@ -131,9 +136,7 @@ inline void ExpectedValuesAggregator::compute_density_cis() {
   const auto shot_noise_minimum = 400.0;
   const auto max_num_bins = _actual_distances.size();
 
-  _weights.resize(max_num_bins);
-  std::fill(_weights.begin(), _weights.end(), 0.0);
-
+  assert(_weights.size() == max_num_bins);
   for (std::size_t ii = 0; ii < max_num_bins; ii++) {
     if (num_sum < shot_noise_minimum) {
       while (num_sum < shot_noise_minimum && ++bound2 < max_num_bins) {

--- a/test/units/expected_values_aggregator/expected_values_aggregator_test.cpp
+++ b/test/units/expected_values_aggregator/expected_values_aggregator_test.cpp
@@ -48,6 +48,14 @@ TEST_CASE("ExpectedValuesAggregator", "[file][short]") {
   }
 
   SECTION("invalid chromosome") { CHECK_THROWS(aggr.weights(Chromosome{99, "A", 10})); }
+
+  SECTION("small chromosome") {
+    const BinTable bins{{Chromosome{0, "chr1", 5}}, 10};
+
+    ExpectedValuesAggregator aggr1(std::make_shared<const BinTable>(bins));
+    CHECK_NOTHROW(aggr1.compute_density());
+    CHECK(aggr1.weights().empty());
+  }
 }
 
 }  // namespace hictk::test::expected_values_aggregator


### PR DESCRIPTION
Address segfault that could occur when computing the expected value vector density for chromosomes whose size is smaller than the bin size.