### PR TITLE
Support for fetching interactions from the lower triangle when it makes sense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,11 +132,16 @@ option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(HICTK_ENABLE_TESTING "Build unit tests" ON)
 option(HICTK_BUILD_EXAMPLES "Build examples" OFF)
 option(HICTK_BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(HICTK_WITH_ARROW "Build with arrow support" ON)
 option(HICTK_WITH_EIGEN "Build with Eigen3 support" ON)
 option(HICTK_BUILD_TOOLS "Build cli tools" ON)
 
 if(HICTK_WITH_EIGEN)
   target_compile_definitions(hictk_project_options INTERFACE HICTK_WITH_EIGEN)
+endif()
+
+if(HICTK_WITH_ARROW)
+  target_compile_definitions(hictk_project_options INTERFACE HICTK_WITH_ARROW)
 endif()
 
 add_subdirectory(src)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Roberto Rossini <roberros@uio.no>
+# Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
 #
 # SPDX-License-Identifier: MIT
 
@@ -9,7 +9,7 @@ from conan.tools.build import check_min_cppstd
 required_conan_version = ">=1.53.0"
 
 
-class NCHGConan(ConanFile):
+class HictkConan(ConanFile):
     name = "hictk"
     description = "Blazing fast toolkit to work with .hic and .cool files."
     license = "MIT"
@@ -36,6 +36,8 @@ class NCHGConan(ConanFile):
         return 17
 
     def requirements(self):
+        self.requires("arrow/16.0.0#c0b940c80fddf319983165f7588c279d")
+        self.requires("boost/1.85.0#7926babdab0a9779cc164d0af6c28d5e", force=True)
         self.requires("bshoshany-thread-pool/4.1.0#be1802a8768416a6c9b1393cf0ce5e9c")
         self.requires("catch2/3.5.4#d346ca291f8f62040fd9c1a891654711")
         self.requires("cli11/2.4.1#afacffd31f631bbb8b7c7d6425fe7a66")
@@ -50,7 +52,8 @@ class NCHGConan(ConanFile):
         self.requires("readerwriterqueue/1.0.6#aaa5ff6fac60c2aee591e9e51b063b83")
         self.requires("span-lite/0.11.0#519fd49fff711674cfed8cd17d4ed422")
         self.requires("spdlog/1.13.0#8e88198fd5b9ee31d329431a6d0ccaa2")
-        self.requires("zstd/1.5.6#67383dae85d33f43823e7751a6745ea1")
+        self.requires("thrift/0.18.1#4e5674c24f99dde562c3926f9cb2ff9d", force=True)
+        self.requires("zstd/1.5.6#67383dae85d33f43823e7751a6745ea1", force=True)
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
@@ -60,6 +63,50 @@ class NCHGConan(ConanFile):
         if self.settings.compiler in ["clang", "gcc"]:
             self.settings.compiler.libcxx = "libstdc++11"
 
+        self.options["arrow"].with_boost = True
+        self.options["arrow"].parquet = False
+        self.options["arrow"].with_thrift = False
+        self.options["boost"].system_no_deprecated = True
+        self.options["boost"].asio_no_deprecated = True
+        self.options["boost"].filesystem_no_deprecated = True
+        self.options["boost"].filesystem_version = 4
+        self.options["boost"].zlib = False
+        self.options["boost"].bzip2 = False
+        self.options["boost"].lzma = False
+        self.options["boost"].zstd = False
+        self.options["boost"].without_atomic = False
+        self.options["boost"].without_charconv = True
+        self.options["boost"].without_chrono = True
+        self.options["boost"].without_container = True
+        self.options["boost"].without_context = True
+        self.options["boost"].without_contract = True
+        self.options["boost"].without_coroutine = True
+        self.options["boost"].without_date_time = True
+        self.options["boost"].without_exception = True
+        self.options["boost"].without_fiber = True
+        self.options["boost"].without_filesystem = False
+        self.options["boost"].without_graph = True
+        self.options["boost"].without_graph_parallel = True
+        self.options["boost"].without_iostreams = True
+        self.options["boost"].without_json = True
+        self.options["boost"].without_locale = True
+        self.options["boost"].without_log = True
+        self.options["boost"].without_math = True
+        self.options["boost"].without_mpi = True
+        self.options["boost"].without_nowide = True
+        self.options["boost"].without_program_options = True
+        self.options["boost"].without_python = True
+        self.options["boost"].without_random = True
+        self.options["boost"].without_regex = True
+        self.options["boost"].without_serialization = True
+        self.options["boost"].without_stacktrace = True
+        self.options["boost"].without_system = False
+        self.options["boost"].without_test = True
+        self.options["boost"].without_thread = True
+        self.options["boost"].without_timer = True
+        self.options["boost"].without_type_erasure = True
+        self.options["boost"].without_url = True
+        self.options["boost"].without_wave = True
         self.options["fmt"].header_only = True
         self.options["hdf5"].enable_cxx = False
         self.options["hdf5"].hl = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -63,8 +63,10 @@ class HictkConan(ConanFile):
         if self.settings.compiler in ["clang", "gcc"]:
             self.settings.compiler.libcxx = "libstdc++11"
 
-        self.options["arrow"].with_boost = True
+        self.options["arrow"].compute = True
         self.options["arrow"].parquet = False
+        self.options["arrow"].with_boost = True
+        self.options["arrow"].with_re2 = True
         self.options["arrow"].with_thrift = False
         self.options["boost"].system_no_deprecated = True
         self.options["boost"].asio_no_deprecated = True

--- a/src/libhictk/cooler/include/hictk/cooler/impl/pixel_selector_impl.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/impl/pixel_selector_impl.hpp
@@ -28,7 +28,7 @@ namespace hictk::cooler {
 inline PixelSelector::PixelSelector(std::shared_ptr<const Index> index,
                                     const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
                                     const Dataset &pixels_count, PixelCoordinates coords,
-                                    std::shared_ptr<const balancing::Weights> weights) noexcept
+                                    std::shared_ptr<const balancing::Weights> weights)
     : PixelSelector(std::move(index), pixels_bin1_id, pixels_bin2_id, pixels_count, coords, coords,
                     std::move(weights)) {}
 
@@ -36,7 +36,7 @@ inline PixelSelector::PixelSelector(std::shared_ptr<const Index> index,
                                     const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
                                     const Dataset &pixels_count, PixelCoordinates coord1,
                                     PixelCoordinates coord2,
-                                    std::shared_ptr<const balancing::Weights> weights) noexcept
+                                    std::shared_ptr<const balancing::Weights> weights)
     : _coord1(std::move(coord1)),
       _coord2(std::move(coord2)),
       _index(std::move(index)),
@@ -46,6 +46,14 @@ inline PixelSelector::PixelSelector(std::shared_ptr<const Index> index,
       _pixels_count(&pixels_count),
       _weights(std::move(weights)) {
   assert(_index);
+  const auto query_is_cis = _coord1.bin1.chrom() == _coord2.bin1.chrom();
+  if ((!query_is_cis && _coord1.bin1 > _coord2.bin1) ||
+      (query_is_cis && _coord1.bin1.start() > _coord2.bin1.start())) {
+    throw std::runtime_error(fmt::format(
+        FMT_STRING("query {}:{}-{}; {}:{}-{}; overlaps with the lower-triangle of the matrix"),
+        _coord1.bin1.chrom().name(), _coord1.bin1.start(), _coord1.bin2.end(),
+        _coord2.bin1.chrom().name(), _coord2.bin1.start(), _coord2.bin2.end()));
+  }
 }
 
 inline PixelSelector::PixelSelector(std::shared_ptr<const Index> index,

--- a/src/libhictk/cooler/include/hictk/cooler/pixel_selector.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/pixel_selector.hpp
@@ -42,12 +42,11 @@ class PixelSelector {
                 std::shared_ptr<const balancing::Weights> weights) noexcept;
   PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                 const Dataset &pixels_bin2_id, const Dataset &pixels_count, PixelCoordinates coords,
-                std::shared_ptr<const balancing::Weights> weights) noexcept;
+                std::shared_ptr<const balancing::Weights> weights);
 
   PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                 const Dataset &pixels_bin2_id, const Dataset &pixels_count, PixelCoordinates coord1,
-                PixelCoordinates coord2,
-                std::shared_ptr<const balancing::Weights> weights) noexcept;
+                PixelCoordinates coord2, std::shared_ptr<const balancing::Weights> weights);
 
   [[nodiscard]] bool operator==(const PixelSelector &other) const noexcept;
   [[nodiscard]] bool operator!=(const PixelSelector &other) const noexcept;

--- a/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
@@ -214,8 +214,9 @@ inline PixelSelector File::fetch(const Chromosome& chrom1, std::uint32_t start1,
                                  const Chromosome& chrom2, std::uint32_t start2, std::uint32_t end2,
                                  balancing::Method norm) const {
   if (chrom1 > chrom2) {
-    throw std::runtime_error(
-        "Query overlaps the lower-triangle of the matrix. This is currently not supported.");
+    throw std::runtime_error(fmt::format(
+        FMT_STRING("query {}:{}-{}; {}:{}-{}; overlaps with the lower-triangle of the matrix"),
+        chrom1.name(), start1, end1, chrom2.name(), start2, end2));
   }
 
   const PixelCoordinates coord1 = {_bins->at(chrom1, start1), _bins->at(chrom1, end1 - 1)};

--- a/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
@@ -33,21 +33,29 @@ namespace hictk::hic {
 inline PixelSelector::PixelSelector(std::shared_ptr<internal::HiCFileReader> hfs_,
                                     std::shared_ptr<const internal::HiCFooter> footer_,
                                     std::shared_ptr<internal::BlockCache> cache_,
-                                    std::shared_ptr<const BinTable> bins_,
-                                    PixelCoordinates coords) noexcept
+                                    std::shared_ptr<const BinTable> bins_, PixelCoordinates coords)
     : PixelSelector(std::move(hfs_), std::move(footer_), std::move(cache_), std::move(bins_),
-                    coords, std::move(coords)) {}
+                    coords, coords) {}
 
 inline PixelSelector::PixelSelector(std::shared_ptr<internal::HiCFileReader> hfs_,
                                     std::shared_ptr<const internal::HiCFooter> footer_,
                                     std::shared_ptr<internal::BlockCache> cache_,
                                     std::shared_ptr<const BinTable> bins_, PixelCoordinates coord1_,
-                                    PixelCoordinates coord2_) noexcept
+                                    PixelCoordinates coord2_)
     : _reader(std::make_shared<internal::HiCBlockReader>(std::move(hfs_), footer_->index(),
                                                          std::move(bins_), std::move(cache_))),
       _footer(std::move(footer_)),
       _coord1(std::make_shared<const PixelCoordinates>(std::move(coord1_))),
-      _coord2(std::make_shared<const PixelCoordinates>(std::move(coord2_))) {}
+      _coord2(std::make_shared<const PixelCoordinates>(std::move(coord2_))) {
+  const auto query_is_cis = _coord1->bin1.chrom() == _coord2->bin1.chrom();
+  if ((!query_is_cis && _coord1->bin1 > _coord2->bin1) ||
+      (query_is_cis && _coord1->bin1.start() > _coord2->bin1.start())) {
+    throw std::runtime_error(fmt::format(
+        FMT_STRING("query {}:{}-{}; {}:{}-{}; overlaps with the lower-triangle of the matrix"),
+        _coord1->bin1.chrom().name(), _coord1->bin1.start(), _coord1->bin2.end(),
+        _coord2->bin1.chrom().name(), _coord2->bin1.start(), _coord2->bin2.end()));
+  }
+}
 
 inline PixelSelector::~PixelSelector() noexcept {
   try {

--- a/src/libhictk/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/libhictk/hic/include/hictk/hic/pixel_selector.hpp
@@ -45,12 +45,12 @@ class PixelSelector {
   PixelSelector(std::shared_ptr<internal::HiCFileReader> hfs_,
                 std::shared_ptr<const internal::HiCFooter> footer_,
                 std::shared_ptr<internal::BlockCache> cache_, std::shared_ptr<const BinTable> bins_,
-                PixelCoordinates coords) noexcept;
+                PixelCoordinates coords);
 
   PixelSelector(std::shared_ptr<internal::HiCFileReader> hfs_,
                 std::shared_ptr<const internal::HiCFooter> footer_,
                 std::shared_ptr<internal::BlockCache> cache_, std::shared_ptr<const BinTable> bins_,
-                PixelCoordinates coord1_, PixelCoordinates coord2_) noexcept;
+                PixelCoordinates coord1_, PixelCoordinates coord2_);
 
   PixelSelector(const PixelSelector &other) = delete;
   PixelSelector(PixelSelector &&other) = default;

--- a/src/libhictk/transformers/CMakeLists.txt
+++ b/src/libhictk/transformers/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+if(HICTK_WITH_ARROW)
+  find_package(Arrow REQUIRED QUIET)
+endif()
+
 add_library(transformers INTERFACE)
 add_library(hictk::transformers ALIAS transformers)
 
@@ -14,3 +18,5 @@ target_sources(
 target_include_directories(transformers INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(transformers INTERFACE hictk::cooler hictk::hic)
+
+target_link_system_libraries(transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:arrow::arrow>")

--- a/src/libhictk/transformers/include/hictk/transformers.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers.hpp
@@ -8,5 +8,6 @@
 #include "hictk/transformers/join_genomic_coords.hpp"
 #include "hictk/transformers/pixel_merger.hpp"
 #include "hictk/transformers/stats.hpp"
+#include "hictk/transformers/to_dataframe.hpp"
 #include "hictk/transformers/to_dense_matrix.hpp"
 #include "hictk/transformers/to_sparse_matrix.hpp"

--- a/src/libhictk/transformers/include/hictk/transformers/impl/common.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/common.hpp
@@ -13,4 +13,4 @@ inline constexpr bool has_coord1_member_fx = false;
 template <typename T>
 inline constexpr bool has_coord1_member_fx<T, std::void_t<decltype(std::declval<T>().coord1())>> =
     true;
-}
+}  // namespace hictk::transformers::internal

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_dataframe_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_dataframe_impl.hpp
@@ -1,0 +1,280 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "hictk/bin_table.hpp"
+#include "hictk/pixel.hpp"
+#include "hictk/reference.hpp"
+
+namespace hictk::transformers {
+
+template <typename PixelIt>
+inline ToDataFrame<PixelIt>::ToDataFrame(PixelIt first, PixelIt last,
+                                         std::shared_ptr<const BinTable> bins,
+                                         std::size_t chunk_size)
+    : _first(std::move(first)), _last(std::move(last)), _bins(std::move(bins)) {
+  if (_bins) {
+    _chrom_id_offset = _bins->chromosomes().at(0).is_all();
+    const auto dict = make_chrom_dict(_bins->chromosomes());
+
+    auto status = _chrom1_builder.InsertMemoValues(*dict);
+    if (!status.ok()) {
+      throw std::runtime_error(status.ToString());
+    }
+
+    status = _chrom2_builder.InsertMemoValues(*dict);
+    if (!status.ok()) {
+      throw std::runtime_error(status.ToString());
+    }
+  }
+
+  if (_bins) {
+    _chrom1_id_buff.reserve(chunk_size);
+    _start1_buff.reserve(chunk_size);
+    _end1_buff.reserve(chunk_size);
+
+    _chrom2_id_buff.reserve(chunk_size);
+    _start2_buff.reserve(chunk_size);
+    _end2_buff.reserve(chunk_size);
+  } else {
+    _bin1_id_buff.reserve(chunk_size);
+    _bin2_id_buff.reserve(chunk_size);
+  }
+
+  _count_buff.reserve(chunk_size);
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::operator()() {
+  if (_bins) {
+    std::for_each(_first, _last, [&](const auto& p) { append(Pixel<N>(*_bins, p)); });
+  } else {
+    std::for_each(_first, _last, [&](const auto& p) { append(p); });
+  }
+
+  if (!_bin1_id.empty() || !_bin1_id_buff.empty()) {
+    return make_coo_table();
+  }
+  return make_bg2_table();
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Schema> ToDataFrame<PixelIt>::coo_schema() const {
+  return arrow::schema({
+      // clang-format off
+      arrow::field("bin1_id", arrow::uint64(), false),
+      arrow::field("bin2_id", arrow::uint64(), false),
+      arrow::field("count",   _count_builder.type(), false)
+      // clang-format on
+  });
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Schema> ToDataFrame<PixelIt>::bg2_schema() const {
+  return arrow::schema({
+      // clang-format off
+      arrow::field("chrom1", arrow::dictionary(arrow::uint32(), arrow::utf8(), true), false),
+      arrow::field("start1", arrow::uint32(), false),
+      arrow::field("end1",   arrow::uint32(), false),
+      arrow::field("chrom2", arrow::dictionary(arrow::uint32(), arrow::utf8(), true), false),
+      arrow::field("start2", arrow::uint32(), false),
+      arrow::field("end2",   arrow::uint32(), false),
+      arrow::field("count",  _count_builder.type(), false)
+      // clang-format on
+  });
+}
+
+template <typename PixelIt>
+inline void ToDataFrame<PixelIt>::append(const Pixel<N>& p) {
+  if (_chrom1_id_buff.size() == _chrom1_id_buff.capacity()) {
+    write_pixels();
+  }
+
+  _chrom1_id_buff.push_back(static_cast<std::int32_t>(p.coords.bin1.chrom().id()) -
+                            _chrom_id_offset);
+  _start1_buff.push_back(p.coords.bin1.start());
+  _end1_buff.push_back(p.coords.bin1.end());
+
+  _chrom2_id_buff.push_back(static_cast<std::int32_t>(p.coords.bin2.chrom().id()) -
+                            _chrom_id_offset);
+  _start2_buff.push_back(p.coords.bin2.start());
+  _end2_buff.push_back(p.coords.bin2.end());
+
+  _count_buff.push_back(p.count);
+}
+
+template <typename PixelIt>
+inline void ToDataFrame<PixelIt>::append(const ThinPixel<N>& p) {
+  if (_bin1_id_buff.size() == _bin1_id_buff.capacity()) {
+    write_thin_pixels();
+  }
+
+  _bin1_id_buff.push_back(p.bin1_id);
+  _bin2_id_buff.push_back(p.bin2_id);
+  _count_buff.push_back(p.count);
+}
+
+template <typename PixelIt>
+inline void ToDataFrame<PixelIt>::append(arrow::StringBuilder& builder, std::string_view data) {
+  const auto status = builder.Append(std::string{data});
+  if (!status.ok()) {
+    throw std::runtime_error(status.ToString());
+  }
+}
+
+template <typename PixelIt>
+template <typename ArrayBuilder, typename T>
+inline void ToDataFrame<PixelIt>::append(ArrayBuilder& builder, const std::vector<T>& data) {
+  const auto status = builder.AppendValues(data);
+  if (!status.ok()) {
+    throw std::runtime_error(status.ToString());
+  }
+}
+
+template <typename PixelIt>
+inline void ToDataFrame<PixelIt>::append(arrow::StringDictionary32Builder& builder,
+                                         const std::vector<std::int32_t>& data) {
+  const auto status = builder.AppendIndices(data.data(), static_cast<std::int64_t>(data.size()));
+  if (!status.ok()) {
+    throw std::runtime_error(status.ToString());
+  }
+}
+
+template <typename PixelIt>
+template <typename ArrayBuilder>
+inline std::shared_ptr<arrow::Array> ToDataFrame<PixelIt>::finish(ArrayBuilder& builder) {
+  auto result = builder.Finish();
+  if (!result.status().ok()) {
+    throw std::runtime_error(result.status().ToString());
+  }
+
+  return result.MoveValueUnsafe();
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_coo_table() {
+  if (!_bin1_id_buff.empty()) {
+    write_thin_pixels();
+  }
+
+  auto table = arrow::Table::Make(coo_schema(), {std::make_shared<arrow::ChunkedArray>(_bin1_id),
+                                                 std::make_shared<arrow::ChunkedArray>(_bin2_id),
+                                                 std::make_shared<arrow::ChunkedArray>(_count)});
+
+  _bin1_id.clear();
+  _bin2_id.clear();
+  _count.clear();
+
+  return table;
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_bg2_table() {
+  if (!_chrom1_id_buff.empty()) {
+    write_pixels();
+  }
+
+  // clang-format off
+  auto table = arrow::Table::Make(
+      bg2_schema(),
+      {std::make_shared<arrow::ChunkedArray>(_chrom1),
+       std::make_shared<arrow::ChunkedArray>(_start1),
+       std::make_shared<arrow::ChunkedArray>(_end1),
+       std::make_shared<arrow::ChunkedArray>(_chrom2),
+       std::make_shared<arrow::ChunkedArray>(_start2),
+       std::make_shared<arrow::ChunkedArray>(_end2),
+       std::make_shared<arrow::ChunkedArray>(_count)});
+  // clang-format on
+
+  _chrom1.clear();
+  _start1.clear();
+  _end1.clear();
+
+  _chrom2.clear();
+  _start2.clear();
+  _end2.clear();
+
+  _count.clear();
+
+  return table;
+}
+
+template <typename PixelIt>
+inline std::shared_ptr<arrow::Array> ToDataFrame<PixelIt>::make_chrom_dict(
+    const hictk::Reference& chroms) {
+  arrow::StringBuilder builder{};
+  for (const auto& chrom : chroms) {
+    if (!chrom.is_all()) {
+      append(builder, std::string{chrom.name()});
+    }
+  }
+
+  return finish(builder);
+}
+
+template <typename PixelIt>
+void ToDataFrame<PixelIt>::write_thin_pixels() {
+  if (!_bin1_id_buff.empty()) {
+    append(_bin1_id_builder, _bin1_id_buff);
+    append(_bin2_id_builder, _bin2_id_buff);
+    append(_count_builder, _count_buff);
+
+    _bin1_id.emplace_back(finish(_bin1_id_builder));
+    _bin2_id.emplace_back(finish(_bin2_id_builder));
+    _count.emplace_back(finish(_count_builder));
+
+    _bin1_id_buff.clear();
+    _bin2_id_buff.clear();
+    _count_buff.clear();
+  }
+}
+
+template <typename PixelIt>
+void ToDataFrame<PixelIt>::write_pixels() {
+  if (!_chrom1_id_buff.empty()) {
+    append(_chrom1_builder, _chrom1_id_buff);
+    append(_start1_builder, _start1_buff);
+    append(_end1_builder, _end1_buff);
+
+    append(_chrom2_builder, _chrom2_id_buff);
+    append(_start2_builder, _start2_buff);
+    append(_end2_builder, _end2_buff);
+
+    append(_count_builder, _count_buff);
+
+    _chrom1.emplace_back(finish(_chrom1_builder));
+    _start1.emplace_back(finish(_start1_builder));
+    _end1.emplace_back(finish(_end1_builder));
+
+    _chrom2.emplace_back(finish(_chrom2_builder));
+    _start2.emplace_back(finish(_start2_builder));
+    _end2.emplace_back(finish(_end2_builder));
+
+    _count.emplace_back(finish(_count_builder));
+
+    _chrom1_id_buff.clear();
+    _start1_buff.clear();
+    _end1_buff.clear();
+
+    _chrom2_id_buff.clear();
+    _start2_buff.clear();
+    _end2_buff.clear();
+
+    _count_buff.clear();
+  }
+}
+
+}  // namespace hictk::transformers

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_dataframe_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_dataframe_impl.hpp
@@ -6,6 +6,8 @@
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
+#include <arrow/compute/api_vector.h>
+#include <arrow/datum.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
 
@@ -22,10 +24,20 @@
 namespace hictk::transformers {
 
 template <typename PixelIt>
-inline ToDataFrame<PixelIt>::ToDataFrame(PixelIt first, PixelIt last,
-                                         std::shared_ptr<const BinTable> bins,
+inline ToDataFrame<PixelIt>::ToDataFrame(PixelIt first, PixelIt last, DataFrameFormat format,
+                                         std::shared_ptr<const BinTable> bins, bool transpose,
                                          std::size_t chunk_size)
-    : _first(std::move(first)), _last(std::move(last)), _bins(std::move(bins)) {
+    : _first(std::move(first)),
+      _last(std::move(last)),
+      _bins(std::move(bins)),
+      _transpose(transpose),
+      _format(format) {
+  if (_format == DataFrameFormat::BG2 && !_bins) {
+    throw std::runtime_error(
+        "hictk::transformers::ToDataFrame: a bin table is required when format is "
+        "DataFrameFormat::BG2");
+  }
+
   if (_bins) {
     _chrom_id_offset = _bins->chromosomes().at(0).is_all();
     const auto dict = make_chrom_dict(_bins->chromosomes());
@@ -49,7 +61,9 @@ inline ToDataFrame<PixelIt>::ToDataFrame(PixelIt first, PixelIt last,
     _chrom2_id_buff.reserve(chunk_size);
     _start2_buff.reserve(chunk_size);
     _end2_buff.reserve(chunk_size);
-  } else {
+  }
+
+  if (!_bins || _transpose) {
     _bin1_id_buff.reserve(chunk_size);
     _bin2_id_buff.reserve(chunk_size);
   }
@@ -65,7 +79,7 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::operator()() {
     std::for_each(_first, _last, [&](const auto& p) { append(p); });
   }
 
-  if (!_bin1_id.empty() || !_bin1_id_buff.empty()) {
+  if (_format == DataFrameFormat::COO) {
     return make_coo_table();
   }
   return make_bg2_table();
@@ -83,24 +97,35 @@ inline std::shared_ptr<arrow::Schema> ToDataFrame<PixelIt>::coo_schema() const {
 }
 
 template <typename PixelIt>
-inline std::shared_ptr<arrow::Schema> ToDataFrame<PixelIt>::bg2_schema() const {
-  return arrow::schema({
-      // clang-format off
-      arrow::field("chrom1", arrow::dictionary(arrow::uint32(), arrow::utf8(), true), false),
-      arrow::field("start1", arrow::uint32(), false),
-      arrow::field("end1",   arrow::uint32(), false),
-      arrow::field("chrom2", arrow::dictionary(arrow::uint32(), arrow::utf8(), true), false),
-      arrow::field("start2", arrow::uint32(), false),
-      arrow::field("end2",   arrow::uint32(), false),
-      arrow::field("count",  _count_builder.type(), false)
-      // clang-format on
-  });
+inline std::shared_ptr<arrow::Schema> ToDataFrame<PixelIt>::bg2_schema(bool with_bin_ids) const {
+  arrow::FieldVector fields{};
+  if (with_bin_ids) {
+    fields.emplace_back(arrow::field("bin1_id", arrow::uint64(), false));
+    fields.emplace_back(arrow::field("bin2_id", arrow::uint64(), false));
+  }
+
+  auto chrom_dict = dictionary(arrow::uint32(), arrow::utf8(), true);
+
+  fields.emplace_back(arrow::field("chrom1", chrom_dict, false));
+  fields.emplace_back(arrow::field("start1", arrow::uint32(), false));
+  fields.emplace_back(arrow::field("end1", arrow::uint32(), false));
+  fields.emplace_back(arrow::field("chrom2", chrom_dict, false));
+  fields.emplace_back(arrow::field("start2", arrow::uint32(), false));
+  fields.emplace_back(arrow::field("end2", arrow::uint32(), false));
+  fields.emplace_back(arrow::field("count", _count_builder.type(), false));
+
+  return arrow::schema(fields);
 }
 
 template <typename PixelIt>
 inline void ToDataFrame<PixelIt>::append(const Pixel<N>& p) {
   if (_chrom1_id_buff.size() == _chrom1_id_buff.capacity()) {
     write_pixels();
+  }
+
+  if (_transpose) {
+    _bin1_id_buff.push_back(p.coords.bin1.id());
+    _bin2_id_buff.push_back(p.coords.bin2.id());
   }
 
   _chrom1_id_buff.push_back(static_cast<std::int32_t>(p.coords.bin1.chrom().id()) -
@@ -170,6 +195,10 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_coo_table() {
     write_thin_pixels();
   }
 
+  if (_transpose) {
+    std::swap(_bin1_id, _bin2_id);
+  }
+
   auto table = arrow::Table::Make(coo_schema(), {std::make_shared<arrow::ChunkedArray>(_bin1_id),
                                                  std::make_shared<arrow::ChunkedArray>(_bin2_id),
                                                  std::make_shared<arrow::ChunkedArray>(_count)});
@@ -177,6 +206,10 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_coo_table() {
   _bin1_id.clear();
   _bin2_id.clear();
   _count.clear();
+
+  if (_transpose) {
+    table = sort_table(table);
+  }
 
   return table;
 }
@@ -187,8 +220,31 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_bg2_table() {
     write_pixels();
   }
 
-  // clang-format off
-  auto table = arrow::Table::Make(
+  std::shared_ptr<arrow::Table> table{};
+  if (_transpose) {
+    std::swap(_bin1_id, _bin2_id);
+    std::swap(_chrom1, _chrom2);
+    std::swap(_start1, _start2);
+    std::swap(_end1, _end2);
+
+    // clang-format off
+    table = arrow::Table::Make(
+      bg2_schema(true),
+      {std::make_shared<arrow::ChunkedArray>(_bin1_id),
+       std::make_shared<arrow::ChunkedArray>(_bin2_id),
+       std::make_shared<arrow::ChunkedArray>(_chrom1),
+       std::make_shared<arrow::ChunkedArray>(_start1),
+       std::make_shared<arrow::ChunkedArray>(_end1),
+       std::make_shared<arrow::ChunkedArray>(_chrom2),
+       std::make_shared<arrow::ChunkedArray>(_start2),
+       std::make_shared<arrow::ChunkedArray>(_end2),
+       std::make_shared<arrow::ChunkedArray>(_count)});
+    // clang-format on
+  } else {
+    assert(_bin1_id.empty());
+    assert(_bin2_id.empty());
+    // clang-format off
+    table = arrow::Table::Make(
       bg2_schema(),
       {std::make_shared<arrow::ChunkedArray>(_chrom1),
        std::make_shared<arrow::ChunkedArray>(_start1),
@@ -197,7 +253,11 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_bg2_table() {
        std::make_shared<arrow::ChunkedArray>(_start2),
        std::make_shared<arrow::ChunkedArray>(_end2),
        std::make_shared<arrow::ChunkedArray>(_count)});
-  // clang-format on
+    // clang-format on
+  }
+
+  _bin1_id.clear();
+  _bin2_id.clear();
 
   _chrom1.clear();
   _start1.clear();
@@ -208,6 +268,21 @@ inline std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::make_bg2_table() {
   _end2.clear();
 
   _count.clear();
+
+  if (_transpose) {
+    table = sort_table(table);
+
+    auto result = table->RemoveColumn(0);
+    if (!result.ok()) {
+      throw std::runtime_error(result.status().ToString());
+    }
+    table = result.MoveValueUnsafe();
+    result = table->RemoveColumn(0);
+    if (!result.ok()) {
+      throw std::runtime_error(result.status().ToString());
+    }
+    table = result.MoveValueUnsafe();
+  }
 
   return table;
 }
@@ -245,6 +320,11 @@ void ToDataFrame<PixelIt>::write_thin_pixels() {
 template <typename PixelIt>
 void ToDataFrame<PixelIt>::write_pixels() {
   if (!_chrom1_id_buff.empty()) {
+    if (_transpose) {
+      append(_bin1_id_builder, _bin1_id_buff);
+      append(_bin2_id_builder, _bin2_id_buff);
+    }
+
     append(_chrom1_builder, _chrom1_id_buff);
     append(_start1_builder, _start1_buff);
     append(_end1_builder, _end1_buff);
@@ -254,6 +334,11 @@ void ToDataFrame<PixelIt>::write_pixels() {
     append(_end2_builder, _end2_buff);
 
     append(_count_builder, _count_buff);
+
+    if (_transpose) {
+      _bin1_id.emplace_back(finish(_bin1_id_builder));
+      _bin2_id.emplace_back(finish(_bin2_id_builder));
+    }
 
     _chrom1.emplace_back(finish(_chrom1_builder));
     _start1.emplace_back(finish(_start1_builder));
@@ -265,6 +350,9 @@ void ToDataFrame<PixelIt>::write_pixels() {
 
     _count.emplace_back(finish(_count_builder));
 
+    _bin1_id_buff.clear();
+    _bin2_id_buff.clear();
+
     _chrom1_id_buff.clear();
     _start1_buff.clear();
     _end1_buff.clear();
@@ -275,6 +363,23 @@ void ToDataFrame<PixelIt>::write_pixels() {
 
     _count_buff.clear();
   }
+}
+
+template <typename PixelIt>
+std::shared_ptr<arrow::Table> ToDataFrame<PixelIt>::sort_table(
+    std::shared_ptr<arrow::Table> table) {
+  const arrow::compute::SortOptions opts{
+      {arrow::compute::SortKey{"bin1_id", arrow::compute::SortOrder::Ascending},
+       arrow::compute::SortKey{"bin2_id", arrow::compute::SortOrder::Ascending}}};
+
+  arrow::Datum vtable{table};
+
+  const auto arg_sorter = arrow::compute::SortIndices(vtable, opts);
+  if (!arg_sorter.ok()) {
+    throw std::runtime_error(arg_sorter.status().ToString());
+  }
+
+  return arrow::compute::Take(vtable, *arg_sorter)->table();
 }
 
 }  // namespace hictk::transformers

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
@@ -15,8 +15,9 @@
 namespace hictk::transformers {
 
 template <typename N, typename PixelSelector>
-inline ToDenseMatrix<N, PixelSelector>::ToDenseMatrix(PixelSelector&& sel, [[maybe_unused]] N n)
-    : _sel(std::move(sel)) {}
+inline ToDenseMatrix<N, PixelSelector>::ToDenseMatrix(PixelSelector&& sel, [[maybe_unused]] N n,
+                                                      bool mirror)
+    : _sel(std::move(sel)), _mirror(mirror) {}
 
 template <typename N, typename PixelSelector>
 inline auto ToDenseMatrix<N, PixelSelector>::operator()()
@@ -27,7 +28,7 @@ inline auto ToDenseMatrix<N, PixelSelector>::operator()()
   const auto num_rows_ = num_rows();
   const auto num_cols_ = num_cols();
 
-  const auto mirror_matrix = chrom1() == chrom2();
+  const auto mirror_matrix = _mirror && chrom1() == chrom2();
 
   using MatrixT = Eigen::Matrix<N, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
   MatrixT matrix = MatrixT::Zero(num_rows_, num_cols_);

--- a/src/libhictk/transformers/include/hictk/transformers/to_dataframe.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_dataframe.hpp
@@ -1,0 +1,158 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#ifdef HICTK_WITH_ARROW
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+
+#include <memory>
+#include <type_traits>
+
+#include "hictk/bin_table.hpp"
+#include "hictk/pixel.hpp"
+#include "hictk/reference.hpp"
+#include "hictk/type_traits.hpp"
+
+namespace hictk::transformers {
+
+namespace internal {
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::uint8_t>>* = nullptr>
+static arrow::UInt8Builder map_cpp_type_to_arrow_builder() {
+  return arrow::UInt8Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::uint16_t>>* = nullptr>
+static arrow::UInt16Builder map_cpp_type_to_arrow_builder() {
+  return arrow::UInt16Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::uint32_t>>* = nullptr>
+static arrow::UInt32Builder map_cpp_type_to_arrow_builder() {
+  return arrow::UInt32Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::uint64_t>>* = nullptr>
+static arrow::UInt64Builder map_cpp_type_to_arrow_builder() {
+  return arrow::UInt64Builder{};
+}
+
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::int8_t>>* = nullptr>
+static arrow::Int8Builder map_cpp_type_to_arrow_builder() {
+  return arrow::Int8Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::int16_t>>* = nullptr>
+static arrow::Int16Builder map_cpp_type_to_arrow_builder() {
+  return arrow::Int16Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::int32_t>>* = nullptr>
+static arrow::Int32Builder map_cpp_type_to_arrow_builder() {
+  return arrow::Int32Builder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, std::int64_t>>* = nullptr>
+static arrow::Int64Builder map_cpp_type_to_arrow_builder() {
+  return arrow::Int64Builder{};
+}
+
+template <typename N, typename std::enable_if_t<std::is_same_v<N, float>>* = nullptr>
+static arrow::FloatBuilder map_cpp_type_to_arrow_builder() {
+  return arrow::FloatBuilder{};
+}
+template <typename N, typename std::enable_if_t<std::is_same_v<N, double>>* = nullptr>
+static arrow::DoubleBuilder map_cpp_type_to_arrow_builder() {
+  return arrow::DoubleBuilder{};
+}
+}  // namespace internal
+
+template <typename PixelIt>
+class ToDataFrame {
+  using PixelT = remove_cvref_t<decltype(*std::declval<PixelIt>())>;
+  using N = decltype(std::declval<PixelIt>()->count);
+  static_assert(std::is_same_v<PixelT, hictk::ThinPixel<N>>);
+
+  PixelIt _first{};
+  PixelIt _last{};
+  std::shared_ptr<const BinTable> _bins{};
+
+  arrow::UInt64Builder _bin1_id_builder{};
+  arrow::UInt64Builder _bin2_id_builder{};
+
+  arrow::StringDictionary32Builder _chrom1_builder{};
+  arrow::UInt32Builder _start1_builder{};
+  arrow::UInt32Builder _end1_builder{};
+
+  arrow::StringDictionary32Builder _chrom2_builder{};
+  arrow::UInt32Builder _start2_builder{};
+  arrow::UInt32Builder _end2_builder{};
+
+  using NBuilder = decltype(internal::map_cpp_type_to_arrow_builder<N>());
+  NBuilder _count_builder{};
+
+  std::vector<std::uint64_t> _bin1_id_buff{};
+  std::vector<std::uint64_t> _bin2_id_buff{};
+
+  std::vector<std::int32_t> _chrom1_id_buff{};
+  std::vector<std::uint32_t> _start1_buff{};
+  std::vector<std::uint32_t> _end1_buff{};
+
+  std::vector<std::int32_t> _chrom2_id_buff{};
+  std::vector<std::uint32_t> _start2_buff{};
+  std::vector<std::uint32_t> _end2_buff{};
+
+  std::vector<N> _count_buff{};
+
+  arrow::ArrayVector _bin1_id{};
+  arrow::ArrayVector _bin2_id{};
+
+  arrow::ArrayVector _chrom1{};
+  arrow::ArrayVector _start1{};
+  arrow::ArrayVector _end1{};
+
+  arrow::ArrayVector _chrom2{};
+  arrow::ArrayVector _start2{};
+  arrow::ArrayVector _end2{};
+
+  arrow::ArrayVector _count{};
+
+  std::int32_t _chrom_id_offset{};
+
+ public:
+  ToDataFrame(PixelIt first_pixel, PixelIt last_pixel,
+              std::shared_ptr<const BinTable> bins = nullptr, std::size_t chunk_size = 256'000);
+
+  [[nodiscard]] std::shared_ptr<arrow::Table> operator()();
+
+ private:
+  [[nodiscard]] std::shared_ptr<arrow::Schema> coo_schema() const;
+  [[nodiscard]] std::shared_ptr<arrow::Schema> bg2_schema() const;
+
+  void append(const Pixel<N>& p);
+  void append(const ThinPixel<N>& p);
+
+  static void append(arrow::StringBuilder& builder, std::string_view data);
+  template <typename ArrayBuilder, typename T>
+  static void append(ArrayBuilder& builder, const std::vector<T>& data);
+  static void append(arrow::StringDictionary32Builder& builder,
+                     const std::vector<std::int32_t>& data);
+
+  template <typename ArrayBuilder>
+  [[nodiscard]] static std::shared_ptr<arrow::Array> finish(ArrayBuilder& builder);
+
+  [[nodiscard]] std::shared_ptr<arrow::Table> make_coo_table();
+  [[nodiscard]] std::shared_ptr<arrow::Table> make_bg2_table();
+
+  [[nodiscard]] static std::shared_ptr<arrow::Array> make_chrom_dict(
+      const hictk::Reference& chroms);
+
+  void write_thin_pixels();
+  void write_pixels();
+};
+
+}  // namespace hictk::transformers
+
+#include "./impl/to_dataframe_impl.hpp"
+
+#endif

--- a/src/libhictk/transformers/include/hictk/transformers/to_dense_matrix.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_dense_matrix.hpp
@@ -23,9 +23,10 @@ class ToDenseMatrix {
   static_assert(std::is_same_v<PixelT, hictk::ThinPixel<N>>);
 
   PixelSelector _sel{};
+  bool _mirror{};
 
  public:
-  ToDenseMatrix(PixelSelector&& selector, N n);
+  ToDenseMatrix(PixelSelector&& selector, N n, bool mirror = true);
   [[nodiscard]] auto operator()() -> Eigen::Matrix<N, Eigen::Dynamic, Eigen::Dynamic>;
 
  private:

--- a/src/libhictk/transformers/include/hictk/transformers/to_sparse_matrix.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_sparse_matrix.hpp
@@ -22,9 +22,10 @@ class ToSparseMatrix {
   static_assert(std::is_same_v<PixelT, hictk::ThinPixel<N>>);
 
   PixelSelector _sel{};
+  bool _transpose{false};
 
  public:
-  ToSparseMatrix(PixelSelector&& selector, N n);
+  ToSparseMatrix(PixelSelector&& selector, N n, bool transpose = false);
   [[nodiscard]] auto operator()() -> Eigen::SparseMatrix<N>;
 
  private:

--- a/test/units/cooler/pixel_selector_2d_test.cpp
+++ b/test/units/cooler/pixel_selector_2d_test.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 
 #include "hictk/cooler/cooler.hpp"
@@ -43,6 +45,13 @@ TEST_CASE("Cooler: pixel selector 2D queries", "[pixel_selector][short]") {
       CHECK(pixels[7].count == 2);
     }
 
+    SECTION("invalid") {
+      SECTION("query overlaps lower triangle") {
+        CHECK_THROWS_WITH(f.fetch("1:6000000-6500000", "1:5000000-5500000"),
+                          Catch::Matchers::ContainsSubstring("overlaps with the lower-triangle"));
+      }
+    }
+
     SECTION("empty") {
       auto selector = f.fetch("1:0-100000");
       CHECK(selector.begin<T>() == selector.end<T>());
@@ -72,6 +81,13 @@ TEST_CASE("Cooler: pixel selector 2D queries", "[pixel_selector][short]") {
       CHECK(pixels[3].count == 3);
       CHECK(pixels[4].count == 7);
       CHECK(pixels[5].count == 1);
+    }
+
+    SECTION("invalid") {
+      SECTION("query overlaps lower triangle") {
+        CHECK_THROWS_WITH(f.fetch("2", "1"),
+                          Catch::Matchers::ContainsSubstring("overlaps with the lower-triangle"));
+      }
     }
 
     SECTION("empty") {

--- a/test/units/transformers/transformers_test.cpp
+++ b/test/units/transformers/transformers_test.cpp
@@ -216,13 +216,22 @@ TEST_CASE("Transformers (cooler)", "[transformers][short]") {
   }
 
   if constexpr (TEST_TO_DENSE_MATRIX) {
-    SECTION("ToDenseMatrix (cis)") {
+    SECTION("ToDenseMatrix (cis) w/ mirroring") {
       const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
       const cooler::File clr(path.string());
-      const auto matrix = ToDenseMatrix(clr.fetch("chr1"), std::int32_t{})();
+      const auto matrix = ToDenseMatrix(clr.fetch("chr1"), std::int32_t{}, true)();
       CHECK(matrix.rows() == 100);
       CHECK(matrix.cols() == 100);
       CHECK(matrix.sum() == 140'900'545);
+    }
+
+    SECTION("ToDenseMatrix (cis) wo/ mirroring") {
+      const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
+      const cooler::File clr(path.string());
+      const auto matrix = ToDenseMatrix(clr.fetch("chr1"), std::int32_t{}, false)();
+      CHECK(matrix.rows() == 100);
+      CHECK(matrix.cols() == 100);
+      CHECK(matrix.sum() == 112'660'799);
     }
 
     SECTION("ToDenseMatrix (trans)") {

--- a/test/units/transformers/transformers_test.cpp
+++ b/test/units/transformers/transformers_test.cpp
@@ -194,23 +194,45 @@ TEST_CASE("Transformers (cooler)", "[transformers][short]") {
   }
 
   if constexpr (TEST_TO_SPARSE_MATRIX) {
-    SECTION("ToSparseMatrix (cis)") {
+    SECTION("ToSparseMatrix (cis) wo/ transpose") {
       const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
       const cooler::File clr(path.string());
-      const auto matrix = ToSparseMatrix(clr.fetch("chr1"), std::int32_t{})();
+      const auto matrix = ToSparseMatrix(clr.fetch("chr1"), std::int32_t{}, false)();
       CHECK(matrix.nonZeros() == 4465);
       CHECK(matrix.rows() == 100);
       CHECK(matrix.cols() == 100);
       CHECK(matrix.sum() == 112'660'799);
+      CHECK(matrix.triangularView<Eigen::StrictlyLower>().sum() == 0);
     }
 
-    SECTION("ToSparseMatrix (trans)") {
+    SECTION("ToSparseMatrix (cis) w/ transpose") {
       const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
       const cooler::File clr(path.string());
-      const auto matrix = ToSparseMatrix(clr.fetch("chr1", "chr2"), std::int32_t{})();
+      const auto matrix = ToSparseMatrix(clr.fetch("chr1"), std::int32_t{}, true)();
+      CHECK(matrix.nonZeros() == 4465);
+      CHECK(matrix.rows() == 100);
+      CHECK(matrix.cols() == 100);
+      CHECK(matrix.sum() == 112'660'799);
+      CHECK(matrix.triangularView<Eigen::StrictlyUpper>().sum() == 0);
+    }
+
+    SECTION("ToSparseMatrix (trans) wo/ transpose") {
+      const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
+      const cooler::File clr(path.string());
+      const auto matrix = ToSparseMatrix(clr.fetch("chr1", "chr2"), std::int32_t{}, false)();
       CHECK(matrix.nonZeros() == 9118);
       CHECK(matrix.rows() == 100);
       CHECK(matrix.cols() == 97);
+      CHECK(matrix.sum() == 6'413'076);
+    }
+
+    SECTION("ToSparseMatrix (trans) w/ transpose") {
+      const auto path = datadir / "cooler/ENCFF993FGR.2500000.cool";
+      const cooler::File clr(path.string());
+      const auto matrix = ToSparseMatrix(clr.fetch("chr1", "chr2"), std::int32_t{}, true)();
+      CHECK(matrix.nonZeros() == 9118);
+      CHECK(matrix.rows() == 97);
+      CHECK(matrix.cols() == 100);
       CHECK(matrix.sum() == 6'413'076);
     }
   }


### PR DESCRIPTION
Support fetching interactions from the matrix lower triangle in the following scenarios:
- Query is materialized as a sparse matrix
- Query is materialized as a dense matrix
- Query is materialized as a table of pixels

Iterating over pixels from the lower triangle is not (and will never be) possible, as doing so would require pre-loading and re-sorting all pixels overlapping a query (defeating the purpose of iterators).

Closes #174
Closes #175