### PR TITLE
For the time being, refuse to build on big-endian architectures

### DIFF
--- a/src/libhictk/hic/CMakeLists.txt
+++ b/src/libhictk/hic/CMakeLists.txt
@@ -18,13 +18,13 @@ set(HICTK_CXX_BYTE_ORDER "${CMAKE_CXX_BYTE_ORDER}" CACHE STRING "Specify the CPU
 
 if(HICTK_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
   message(STATUS "Detected ${HICTK_CXX_BYTE_ORDER} architecture.")
-  message(FATAL_ERROR "hictk::hic cannot be built on big-endian architecture.")
+  message(FATAL_ERROR "hictk::hic cannot be built on machines with big-endian architecture.")
 elseif(HICTK_CXX_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
   message(STATUS "Detected ${HICTK_CXX_BYTE_ORDER} architecture.")
 else()
   message(
     FATAL_ERROR
-      "Unable to detect the CPU architecture endiannes: please specify the endianness of the target architecture with -DHICTK_CXX_BYTE_ORDER=*_ENDIAN.\nSee https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_BYTE_ORDER.html for more details."
+      "Unable to detect the CPU architecture endiannes.\nPlease specify the endianness of the target architecture with -DHICTK_CXX_BYTE_ORDER=*_ENDIAN.\nSee https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_BYTE_ORDER.html for more details."
   )
 endif()
 


### PR DESCRIPTION
hictk itself can be built on both little and big-endian architectures. However, the hic library will be quite limited on big-endian archs. These are the current limitations:
- Creating .hic files will work, but the files will only be readable by hictk and only on other big-endian machines
- Reading .hic files will not work, unless files were created by hictk running on big-endian machines (see above)

The above limitations are due to the use of reinterpret_cast<> and raw std::fstream methods to serialize binary data to disk. The .hic file specification does not mandate the endianness that should be used to read and write .hic files, however virtually all .hic files are generated on little-endian machines, so the byte order of the serialized data is also little-endian, making little-endian the de-facto byte order standard.

It is my understanding that machines with big-endian architecture are not that common in desktop/HPC environments used for bioinformatics, so supporting big-endian architectures is likely not a pressing matter.

Supporting big-endian architecture can be achieved by manually converting binary types stored in BinaryBuffers to little-endian before casting them to char* for serialization.
This can be achieved with the help of libraries such as Boost.Endian.

As this conversion is only needed on big-endian machines, extra care should be taken to ensure that the implementation of this feature does not add build nor runtime costs on little-endian machines (i.e. hictk should link to boost only on big-endian platforms and the code performing endianness conversion should be wrapped in if constexpr and/or disabled with std::enable_if as appropriate).