### PR TITLE
Allow dynamically linking to Arrow libs even when building with static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ option(HICTK_ENABLE_TESTING "Build unit tests" ON)
 option(HICTK_BUILD_EXAMPLES "Build examples" OFF)
 option(HICTK_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(HICTK_WITH_ARROW "Build with arrow support" ON)
+option(HICTK_WITH_ARROW_SHARED "Force dynamic linking to Arrow libs" OFF)
 option(HICTK_WITH_EIGEN "Build with Eigen3 support" ON)
 option(HICTK_BUILD_TOOLS "Build cli tools" ON)
 
@@ -142,6 +143,12 @@ endif()
 
 if(HICTK_WITH_ARROW)
   target_compile_definitions(hictk_project_options INTERFACE HICTK_WITH_ARROW)
+endif()
+
+if(BUILD_SHARED_LIBS)
+  set(HICTK_WITH_ARROW_SHARED
+      ON
+      CACHE BOOL "Force dynamic linking to Arrow libs")
 endif()
 
 add_subdirectory(src)

--- a/src/libhictk/transformers/CMakeLists.txt
+++ b/src/libhictk/transformers/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(transformers INTERFACE "$<BUILD_INTERFACE:${CMAKE_CUR
                                                   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(transformers INTERFACE hictk::cooler hictk::hic)
 
-if(BUILD_SHARED_LIBS)
+if(HICTK_WITH_ARROW_SHARED)
   target_link_system_libraries(transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_shared>")
 else()
   target_link_system_libraries(transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_static>")


### PR DESCRIPTION
Introduce a new build knob `HICTK_WITH_ARROW_SHARED` to force dynamic linking to the Arrow libs even when `BUILD_SHARED_LIBS=OFF`.

This is mostly needed to workaround a segfault that occurs under very specific conditions due to (I think) ABI incompatibilities.

The segfault occurs when the following conditions are met:
- Project is built on Windows using a very recent version of MSVC (e.g.  19.40.33813.0)
- `hictk` is statically linked to `arrow` (the lib version does not seem to matter)
- `hictk` is included by a third-party project
- The third-party project dynamically links to `arrow` (again the lib version does not seem to matter)

The segfault was observed while developing `hictkpy` (see https://github.com/paulsengroup/hictkpy/pull/56 for more details).

Notably, the segfault is triggered upon calling `hictkpy::PixelSelector::to_df()`.
However, for some obscure reason, this only happens for certain queries.

Running the same queries directly from `hictk` through the C++ API does not result in a segfault (nor does it raise any error when building `hictk` with ASAN).