### PR TITLE
Improve error message when temporary folder cannot be safely determined

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -44,6 +44,7 @@ env:
   CCACHE_COMPRESSLEVEL: "13"
   CCACHE_MAXSIZE: "200M"
   CONAN_HOME: "/opt/conan/"
+  HICTK_CI: "1"
 
 jobs:
   cache-test-dataset:

--- a/.github/workflows/fuzzy-testing.yml
+++ b/.github/workflows/fuzzy-testing.yml
@@ -103,6 +103,7 @@ jobs:
 
     env:
       CONAN_HOME: '/root/.conan2'
+      HICTK_CI: '1'
 
     steps:
       - name: Clone hictk

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -38,6 +38,7 @@ env:
   CCACHE_COMPRESSLEVEL: "1"
   CCACHE_MAXSIZE: "250M"
   CONAN_HOME: "${{ github.workspace }}/.conan2"
+  HICTK_CI: "1"
   HOMEBREW_NO_AUTO_UPDATE: "1"
 
 defaults:

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -43,6 +43,7 @@ env:
   CCACHE_COMPRESSLEVEL: "13"
   CCACHE_MAXSIZE: "200M"
   CONAN_HOME: "/opt/conan/"
+  HICTK_CI: "1"
 
 jobs:
   run-clang-tidy:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -145,6 +145,7 @@ jobs:
       CCACHE_COMPRESSLEVEL: "1"
       CCACHE_MAXSIZE: "350M"
       CONAN_HOME: "/opt/conan/"
+      HICTK_CI: "1"
 
     steps:
       - uses: actions/checkout@v4
@@ -324,6 +325,9 @@ jobs:
       image: ghcr.io/paulsengroup/ci-docker-images/${{ matrix.os }}-cxx-${{ matrix.compiler }}:latest
       options: "--user=root"
 
+    env:
+      HICTK_CI: "1"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -376,6 +380,9 @@ jobs:
     container:
       image: ghcr.io/paulsengroup/ci-docker-images/hictk/ubuntu-24.04:latest
       options: "--user=root"
+
+    env:
+      HICTK_CI: "1"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,6 +38,7 @@ env:
   CCACHE_COMPRESSLEVEL: "1"
   CCACHE_MAXSIZE: "250M"
   CONAN_HOME: "${{ github.workspace }}/.conan2"
+  HICTK_CI: "1"
 
 defaults:
   run:

--- a/benchmark/hic_creation/hic_creation.cpp
+++ b/benchmark/hic_creation/hic_creation.cpp
@@ -13,6 +13,7 @@
 #include <hictk/cooler/cooler.hpp>
 #include <hictk/hic/file_writer.hpp>
 #include <hictk/pixel.hpp>
+#include <hictk/tmpdir.hpp>
 #include <vector>
 
 using namespace hictk;
@@ -77,9 +78,9 @@ int main(int argc, char **argv) noexcept {
     for (std::size_t i = 0; i < config.iterations; ++i) {
       const auto t0 = std::chrono::system_clock::now();
       {
-        hic::internal::HiCFileWriter writer(config.out_path.string(), chroms, {f.resolution()},
-                                            "unknown", config.threads, config.chunk_size,
-                                            std::filesystem::temp_directory_path(), 11, true);
+        hic::internal::HiCFileWriter writer(
+            config.out_path.string(), chroms, {f.resolution()}, "unknown", config.threads,
+            config.chunk_size, internal::TmpDir::default_temp_directory_path(), 11, true);
         for (const auto &chunk : pixels) {
           writer.add_pixels(f.resolution(), chunk.begin(), chunk.end());
           num_pixels += chunk.size();

--- a/src/hictk/cli/cli_balance.cpp
+++ b/src/hictk/cli/cli_balance.cpp
@@ -18,6 +18,7 @@
 
 #include "hictk/file.hpp"
 #include "hictk/hic/validation.hpp"
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -392,6 +393,7 @@ void Cli::transform_args_balance_subcommand() {
 
 void Cli::transform_args_ice_balance_subcommand() {
   auto& c = std::get<BalanceICEConfig>(_config);
+  const auto& sc = *_cli.get_subcommand("balance")->get_subcommand("ice");
 
   if (c.name.empty()) {
     if (c.mode == "cis") {
@@ -410,6 +412,10 @@ void Cli::transform_args_ice_balance_subcommand() {
     input_path = cooler::File(c.path_to_input.string()).path();
   }
 
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
+  }
+
   // in spdlog, high numbers correspond to low log levels
   assert(c.verbosity > 0 && c.verbosity < 5);
   c.verbosity = static_cast<std::uint8_t>(spdlog::level::critical) - c.verbosity;
@@ -417,6 +423,7 @@ void Cli::transform_args_ice_balance_subcommand() {
 
 void Cli::transform_args_scale_balance_subcommand() {
   auto& c = std::get<BalanceSCALEConfig>(_config);
+  const auto& sc = *_cli.get_subcommand("balance")->get_subcommand("scale");
 
   if (c.name.empty()) {
     if (c.mode == "cis") {
@@ -433,6 +440,10 @@ void Cli::transform_args_scale_balance_subcommand() {
   auto input_path = c.path_to_input;
   if (input_format == "cool") {
     input_path = cooler::File(c.path_to_input.string()).path();
+  }
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
   }
 
   // in spdlog, high numbers correspond to low log levels

--- a/src/hictk/cli/cli_convert.cpp
+++ b/src/hictk/cli/cli_convert.cpp
@@ -25,6 +25,7 @@
 #include "hictk/hic.hpp"
 #include "hictk/hic/utils.hpp"
 #include "hictk/hic/validation.hpp"
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -242,6 +243,10 @@ void Cli::transform_args_convert_subcommand() {
       c.normalization_methods =
           File(c.path_to_input.string(), c.resolutions.back()).avail_normalizations();
     }
+  }
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
   }
 
   // in spdlog, high numbers correspond to low log levels

--- a/src/hictk/cli/cli_fix_mcool.cpp
+++ b/src/hictk/cli/cli_fix_mcool.cpp
@@ -17,6 +17,7 @@
 #include <variant>
 #include <vector>
 
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -143,6 +144,11 @@ void Cli::validate_fix_mcool_subcommand() const {
 
 void Cli::transform_args_fix_mcool_subcommand() {
   auto& c = std::get<FixMcoolConfig>(_config);
+  const auto& sc = *_cli.get_subcommand("fix-mcool");
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
+  }
 
   // in spdlog, high numbers correspond to low log levels
   assert(c.verbosity > 0 && c.verbosity < 5);

--- a/src/hictk/cli/cli_load.cpp
+++ b/src/hictk/cli/cli_load.cpp
@@ -16,6 +16,7 @@
 #include <variant>
 #include <vector>
 
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -209,6 +210,10 @@ void Cli::transform_args_load_subcommand() {
 
   if (sc.get_option("--compression-lvl")->empty()) {
     c.compression_lvl = c.output_format == "hic" ? 10 : 6;
+  }
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
   }
 
   // in spdlog, high numbers correspond to low log levels

--- a/src/hictk/cli/cli_merge.cpp
+++ b/src/hictk/cli/cli_merge.cpp
@@ -17,6 +17,7 @@
 #include <variant>
 #include <vector>
 
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -190,6 +191,10 @@ void Cli::transform_args_merge_subcommand() {
 
   if (sc.get_option("--compression-lvl")->empty()) {
     c.compression_lvl = c.output_format == "hic" ? 10 : 6;
+  }
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
   }
 
   // in spdlog, high numbers correspond to low log levels

--- a/src/hictk/cli/cli_zoomify.cpp
+++ b/src/hictk/cli/cli_zoomify.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "hictk/cooler/cooler.hpp"
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
 #include "hictk/tools/config.hpp"
 
@@ -296,6 +297,10 @@ void Cli::transform_args_zoomify_subcommand() {
 
   if (sc.get_option("--compression-lvl")->empty()) {
     c.compression_lvl = c.output_format == "hic" ? 10 : 6;
+  }
+
+  if (sc.get_option("--tmpdir")->empty()) {
+    c.tmp_dir = hictk::internal::TmpDir::default_temp_directory_path();
   }
 }
 

--- a/src/hictk/include/hictk/tools/config.hpp
+++ b/src/hictk/include/hictk/tools/config.hpp
@@ -13,13 +13,12 @@
 
 #include "hictk/balancing/methods.hpp"
 #include "hictk/hic/common.hpp"
-#include "hictk/tmpdir.hpp"
 
 namespace hictk::tools {
 
 struct BalanceICEConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{hictk::internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
 
   std::string mode{"gw"};
   std::size_t masked_diags{2};
@@ -43,7 +42,7 @@ struct BalanceICEConfig {
 
 struct BalanceSCALEConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
 
   std::string mode{"gw"};
   double max_percentile{10};
@@ -65,7 +64,7 @@ struct BalanceSCALEConfig {
 
 struct BalanceVCConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};  // unused
+  std::filesystem::path tmp_dir{};  // unused
 
   std::string mode{"gw"};
   bool rescale_marginals{true};
@@ -80,7 +79,7 @@ struct BalanceVCConfig {
 struct ConvertConfig {
   std::filesystem::path path_to_input{};
   std::filesystem::path path_to_output{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
   std::string input_format{};
   std::string output_format{};
 
@@ -125,7 +124,7 @@ struct DumpConfig {
 struct FixMcoolConfig {
   std::filesystem::path path_to_input{};
   std::filesystem::path path_to_output{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
 
   bool skip_balancing{false};
   bool check_base_resolution{false};
@@ -144,7 +143,7 @@ struct LoadConfig {
 
   std::filesystem::path path_to_chrom_sizes{};
   std::filesystem::path path_to_bin_table{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
   std::uint32_t bin_size{};
 
   std::string format{};
@@ -172,7 +171,7 @@ struct MergeConfig {
   std::string output_format{};
   std::uint32_t resolution{};
 
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
 
   std::size_t chunk_size{10'000'000};
   std::uint32_t compression_lvl{9};
@@ -203,7 +202,7 @@ struct ZoomifyConfig {
   std::filesystem::path path_to_output{};
   std::string input_format{};
   std::string output_format{};
-  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
+  std::filesystem::path tmp_dir{};
 
   std::vector<std::uint32_t> resolutions{};
   bool copy_base_resolution{true};

--- a/src/hictk/include/hictk/tools/config.hpp
+++ b/src/hictk/include/hictk/tools/config.hpp
@@ -13,12 +13,13 @@
 
 #include "hictk/balancing/methods.hpp"
 #include "hictk/hic/common.hpp"
+#include "hictk/tmpdir.hpp"
 
 namespace hictk::tools {
 
 struct BalanceICEConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{hictk::internal::TmpDir::default_temp_directory_path()};
 
   std::string mode{"gw"};
   std::size_t masked_diags{2};
@@ -42,7 +43,7 @@ struct BalanceICEConfig {
 
 struct BalanceSCALEConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
 
   std::string mode{"gw"};
   double max_percentile{10};
@@ -64,7 +65,7 @@ struct BalanceSCALEConfig {
 
 struct BalanceVCConfig {
   std::filesystem::path path_to_input{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};  // unused
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};  // unused
 
   std::string mode{"gw"};
   bool rescale_marginals{true};
@@ -79,7 +80,7 @@ struct BalanceVCConfig {
 struct ConvertConfig {
   std::filesystem::path path_to_input{};
   std::filesystem::path path_to_output{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
   std::string input_format{};
   std::string output_format{};
 
@@ -124,7 +125,7 @@ struct DumpConfig {
 struct FixMcoolConfig {
   std::filesystem::path path_to_input{};
   std::filesystem::path path_to_output{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
 
   bool skip_balancing{false};
   bool check_base_resolution{false};
@@ -143,7 +144,7 @@ struct LoadConfig {
 
   std::filesystem::path path_to_chrom_sizes{};
   std::filesystem::path path_to_bin_table{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
   std::uint32_t bin_size{};
 
   std::string format{};
@@ -171,7 +172,7 @@ struct MergeConfig {
   std::string output_format{};
   std::uint32_t resolution{};
 
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
 
   std::size_t chunk_size{10'000'000};
   std::uint32_t compression_lvl{9};
@@ -202,7 +203,7 @@ struct ZoomifyConfig {
   std::filesystem::path path_to_output{};
   std::string input_format{};
   std::string output_format{};
-  std::filesystem::path tmp_dir{std::filesystem::temp_directory_path()};
+  std::filesystem::path tmp_dir{internal::TmpDir::default_temp_directory_path()};
 
   std::vector<std::uint32_t> resolutions{};
   bool copy_base_resolution{true};

--- a/src/libhictk/common/include/hictk/tmpdir.hpp
+++ b/src/libhictk/common/include/hictk/tmpdir.hpp
@@ -16,6 +16,7 @@
 #include <fmt/std.h>
 
 #include <atomic>
+#include <cstdlib>
 #include <filesystem>
 #include <utility>
 
@@ -37,8 +38,12 @@ class TmpDir {
  public:
   [[maybe_unused]] TmpDir() {
     try {
-      _path = create_uniq_temp_dir(std::filesystem::temp_directory_path());
+      _path = create_uniq_temp_dir(default_temp_directory_path());
     } catch (const std::filesystem::filesystem_error&) {
+      const auto called_from_ci = std::getenv("HICTK_CI") != nullptr;  // NOLINT(*-mt-unsafe)
+      if (!called_from_ci) {
+        throw;
+      }
       // Workaround spurious CI failures due to missing /tmp folder exception
       _path = create_uniq_temp_dir(std::filesystem::current_path());
     }
@@ -83,6 +88,24 @@ class TmpDir {
 
   TmpDir& operator=(const TmpDir& other) = delete;
   TmpDir& operator=(TmpDir&& other) = delete;
+
+  [[nodiscard]] static std::filesystem::path default_temp_directory_path() {
+    try {
+      return std::filesystem::temp_directory_path();
+    } catch (const std::filesystem::filesystem_error& e) {
+      if (e.path1().empty()) {
+        throw std::filesystem::filesystem_error(
+            "unable to safely determine the path where to store temporary files: please make sure "
+            "the environment variable TMPDIR is defined and pointing to an existing folder",
+            e.code());
+      }
+      throw std::filesystem::filesystem_error(
+          fmt::format(FMT_STRING("unable to safely determine the path where to store temporary "
+                                 "files: temporary folder is set to {} but folder does not exists"),
+                      e.path1()),
+          e.code());
+    }
+  }
 
   [[nodiscard]] static std::filesystem::path create_uniq_temp_dir(
       const std::filesystem::path& tmpdir) {

--- a/src/libhictk/common/include/hictk/tmpdir.hpp
+++ b/src/libhictk/common/include/hictk/tmpdir.hpp
@@ -100,9 +100,10 @@ class TmpDir {
             e.code());
       }
       throw std::filesystem::filesystem_error(
-          fmt::format(FMT_STRING("unable to safely determine the path where to store temporary "
-                                 "files: temporary folder is set to {} but folder does not exists"),
-                      e.path1()),
+          fmt::format(
+              FMT_STRING("unable to safely determine the path where to store temporary "
+                         "files: temporary folder is set to \"{}\" but folder does not exists"),
+              e.path1()),
           e.code());
     }
   }

--- a/src/libhictk/common/include/hictk/tmpdir.hpp
+++ b/src/libhictk/common/include/hictk/tmpdir.hpp
@@ -102,7 +102,7 @@ class TmpDir {
       throw std::filesystem::filesystem_error(
           fmt::format(
               FMT_STRING("unable to safely determine the path where to store temporary "
-                         "files: temporary folder is set to \"{}\" but folder does not exists"),
+                         "files: temporary folder is set to \"{}\" but folder does not exist"),
               e.path1()),
           e.code());
     }

--- a/src/libhictk/hic/include/hictk/hic/file_writer.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer.hpp
@@ -144,12 +144,13 @@ class HiCFileWriter {
  public:
   HiCFileWriter() = default;
   explicit HiCFileWriter(std::string_view path_, std::size_t n_threads = 1);
-  HiCFileWriter(std::string_view path_, Reference chromosomes_,
-                std::vector<std::uint32_t> resolutions_, std::string_view assembly_ = "unknown",
-                std::size_t n_threads = 1, std::size_t chunk_size = 10'000'000,
-                const std::filesystem::path& tmpdir = std::filesystem::temp_directory_path(),
-                std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false,
-                std::size_t buffer_size = 32'000'000);
+  HiCFileWriter(
+      std::string_view path_, Reference chromosomes_, std::vector<std::uint32_t> resolutions_,
+      std::string_view assembly_ = "unknown", std::size_t n_threads = 1,
+      std::size_t chunk_size = 10'000'000,
+      const std::filesystem::path& tmpdir = hictk::internal::TmpDir::default_temp_directory_path(),
+      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false,
+      std::size_t buffer_size = 32'000'000);
 
   [[nodiscard]] std::string_view path() const noexcept;
   [[nodiscard]] const Reference& chromosomes() const noexcept;

--- a/src/libhictk/hic/include/hictk/hic/file_zoomify.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_zoomify.hpp
@@ -4,11 +4,15 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <string_view>
 #include <vector>
 
 #include "hictk/filestream.hpp"
 #include "hictk/hic/file_writer.hpp"
+#include "hictk/tmpdir.hpp"
 
 namespace hictk::hic::internal {
 
@@ -18,11 +22,12 @@ class HiCFileZoomify {
   HiCFileWriter _hfw{};
 
  public:
-  HiCFileZoomify(std::string_view input_hic, std::string_view output_hic,
-                 const std::vector<std::uint32_t>& resolutions, std::size_t n_threads = 1,
-                 std::size_t chunk_size = 10'000'000,
-                 const std::filesystem::path& tmpdir = std::filesystem::temp_directory_path(),
-                 std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false);
+  HiCFileZoomify(
+      std::string_view input_hic, std::string_view output_hic,
+      const std::vector<std::uint32_t>& resolutions, std::size_t n_threads = 1,
+      std::size_t chunk_size = 10'000'000,
+      const std::filesystem::path& tmpdir = hictk::internal::TmpDir::default_temp_directory_path(),
+      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false);
   void zoomify();
 
  private:

--- a/src/libhictk/hic/include/hictk/hic/utils.hpp
+++ b/src/libhictk/hic/include/hictk/hic/utils.hpp
@@ -4,27 +4,31 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <string_view>
 #include <vector>
+
+#include "hictk/tmpdir.hpp"
 
 namespace hictk::hic::utils {
 
 /// Iterable of hictk::hic::File or strings
 template <typename Str>
-void merge(Str first_file, Str last_file, std::string_view dest_file, std::uint32_t resolution,
-           const std::filesystem::path& tmp_dir = std::filesystem::temp_directory_path(),
-           bool overwrite_if_exists = false, std::size_t chunk_size = 500'000,
-           std::size_t n_threads = 1, std::uint32_t compression_lvl = 11,
-           bool skip_all_vs_all = false);
+void merge(
+    Str first_file, Str last_file, std::string_view dest_file, std::uint32_t resolution,
+    const std::filesystem::path& tmp_dir = hictk::internal::TmpDir::default_temp_directory_path(),
+    bool overwrite_if_exists = false, std::size_t chunk_size = 500'000, std::size_t n_threads = 1,
+    std::uint32_t compression_lvl = 11, bool skip_all_vs_all = false);
 
 template <typename PixelIt>
-void merge(const std::vector<PixelIt>& heads, const std::vector<PixelIt>& tails,
-           const BinTable& bins, std::string_view dest_file, std::string_view assembly = "unknown",
-           const std::filesystem::path& tmp_dir = std::filesystem::temp_directory_path(),
-           bool overwrite_if_exists = false, std::size_t chunk_size = 500'000,
-           std::size_t n_threads = 1, std::uint32_t compression_lvl = 11,
-           bool skip_all_vs_all = false);
+void merge(
+    const std::vector<PixelIt>& heads, const std::vector<PixelIt>& tails, const BinTable& bins,
+    std::string_view dest_file, std::string_view assembly = "unknown",
+    const std::filesystem::path& tmp_dir = hictk::internal::TmpDir::default_temp_directory_path(),
+    bool overwrite_if_exists = false, std::size_t chunk_size = 500'000, std::size_t n_threads = 1,
+    std::uint32_t compression_lvl = 11, bool skip_all_vs_all = false);
 
 [[nodiscard]] std::vector<std::uint32_t> list_resolutions(const std::filesystem::path& path,
                                                           bool sorted = true);


### PR DESCRIPTION
This PR introduces three changes:
- Improve the error message issued by `hictk` when the path to a temporary directory cannot be safely determined
- In case of errors, check whether the `HICTK_CI` env variable is defined - this is used to workaround known issues with tmp folders in the CI environment
- Avoid raising errors when there are issues with the tmpdir detection, and this clearly won't lead to any issues (e.g. when calling `hictk --help`)

Closes https://github.com/paulsengroup/hictk/issues/193