### PR TITLE
Make hictk::common depend on the git-watcher target

### DIFF
--- a/src/libhictk/common/CMakeLists.txt
+++ b/src/libhictk/common/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(zstd REQUIRED)
 
 add_library(common INTERFACE)
 add_library(hictk::common ALIAS common)
+add_dependencies(common _hictk_check_git)
 
 target_sources(
   common


### PR DESCRIPTION
This enables building individual targets without the need to call `cmake --build build -t all` first.