### PR TITLE
Fix bug when fetching normalized interactions as dense matrices

### DIFF
--- a/benchmark/pixel_formatting/pixel_formatting.cpp
+++ b/benchmark/pixel_formatting/pixel_formatting.cpp
@@ -20,13 +20,13 @@ struct Config {
 };
 
 template <typename PixelT>
-[[nodiscard]] static std::size_t print_pixels(const std::vector<PixelT> &pixels) {
+[[nodiscard]] static std::ptrdiff_t print_pixels(const std::vector<PixelT> &pixels) {
   auto *dev_null = std::fopen("/dev/null", "w");
   std::for_each(pixels.begin(), pixels.end(),
                 [&](const auto &p) { fmt::print(dev_null, FMT_COMPILE("{}\n"), p); });
   std::fclose(dev_null);
 
-  return pixels.size();
+  return static_cast<std::ptrdiff_t>(pixels.size());
 }
 
 // NOLINTNEXTLINE(bugprone-exception-escape)

--- a/src/libhictk/file/include/hictk/file.hpp
+++ b/src/libhictk/file/include/hictk/file.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "hictk/balancing/methods.hpp"
+#include "hictk/balancing/weights.hpp"
 #include "hictk/bin_table.hpp"
 #include "hictk/cooler/cooler.hpp"
 #include "hictk/cooler/pixel_selector.hpp"
@@ -30,13 +31,15 @@ class PixelSelector {
   using PixelSelectorVar =
       std::variant<cooler::PixelSelector, hic::PixelSelector, hic::PixelSelectorAll>;
   PixelSelectorVar _sel{cooler::PixelSelector{}};
+  std::shared_ptr<const balancing::Weights> _weights{};
 
  public:
   template <typename N>
   class iterator;
 
   template <typename PixelSelectorT>
-  explicit PixelSelector(PixelSelectorT selector);
+  explicit PixelSelector(PixelSelectorT selector,
+                         std::shared_ptr<const balancing::Weights> weights);
 
   template <typename N>
   [[nodiscard]] auto begin(bool sorted = true) const -> iterator<N>;
@@ -58,6 +61,8 @@ class PixelSelector {
   [[nodiscard]] std::shared_ptr<const BinTable> bins_ptr() const noexcept;
 
   [[nodiscard]] PixelSelector fetch(PixelCoordinates coord1_, PixelCoordinates coord2_) const;
+
+  [[nodiscard]] const balancing::Weights &weights() const noexcept;
 
   template <typename PixelSelectorT>
   [[nodiscard]] constexpr const PixelSelectorT &get() const noexcept;
@@ -159,6 +164,8 @@ class File {
   [[nodiscard]] bool has_normalization(std::string_view normalization) const;
   [[nodiscard]] std::vector<balancing::Method> avail_normalizations() const;
   [[nodiscard]] const balancing::Weights &normalization(std::string_view normalization_) const;
+  [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(
+      std::string_view normalization_) const;
 
   template <typename FileT>
   [[nodiscard]] constexpr const FileT &get() const noexcept;

--- a/src/libhictk/hic/include/hictk/hic.hpp
+++ b/src/libhictk/hic/include/hictk/hic.hpp
@@ -94,6 +94,15 @@ class File {
   [[nodiscard]] const balancing::Weights &normalization(balancing::Method norm) const;
   [[nodiscard]] const balancing::Weights &normalization(std::string_view norm) const;
 
+  [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(
+      balancing::Method norm, const Chromosome &chrom) const;
+  [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(
+      std::string_view norm, const Chromosome &chrom) const;
+  [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(
+      balancing::Method norm) const;
+  [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(
+      std::string_view norm) const;
+
   [[nodiscard]] std::vector<double> expected_values(
       const Chromosome &chrom,
       const balancing::Method &normalization_ = balancing::Method::NONE()) const;

--- a/src/libhictk/hic/include/hictk/hic/cache.hpp
+++ b/src/libhictk/hic/include/hictk/hic/cache.hpp
@@ -92,6 +92,9 @@ class WeightCache {
   [[nodiscard]] auto find_or_emplace(std::uint32_t chrom_id, balancing::Method norm) -> Value;
   [[nodiscard]] auto find_or_emplace(const Chromosome& chrom, balancing::Method norm) -> Value;
 
+  [[nodiscard]] auto at(std::uint32_t chrom_id, balancing::Method norm) const -> Value;
+  [[nodiscard]] auto at(const Chromosome& chrom, balancing::Method norm) const -> Value;
+
   void clear() noexcept;
   [[nodiscard]] std::size_t size() const noexcept;
 };

--- a/src/libhictk/hic/include/hictk/hic/cache.hpp
+++ b/src/libhictk/hic/include/hictk/hic/cache.hpp
@@ -89,8 +89,8 @@ class WeightCache {
  public:
   WeightCache() = default;
 
-  [[nodiscard]] auto find_or_emplace(std::uint32_t chrom_id, balancing::Method norm) -> Value;
-  [[nodiscard]] auto find_or_emplace(const Chromosome& chrom, balancing::Method norm) -> Value;
+  [[nodiscard]] auto get_or_init(std::uint32_t chrom_id, balancing::Method norm) -> Value;
+  [[nodiscard]] auto get_or_init(const Chromosome& chrom, balancing::Method norm) -> Value;
 
   [[nodiscard]] auto at(std::uint32_t chrom_id, balancing::Method norm) const -> Value;
   [[nodiscard]] auto at(const Chromosome& chrom, balancing::Method norm) const -> Value;

--- a/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
@@ -747,7 +747,7 @@ inline const balancing::Weights &PixelSelectorAll::weights() const {
         "PixelSelectorAll::weights() was called on an instance of PixelSelectorAll with null "
         "_weight_cache");
   }
-  auto weights = _weight_cache->find_or_emplace(0, normalization());
+  auto weights = _weight_cache->get_or_init(0, normalization());
   if (!weights->empty()) {
     return *weights;
   }

--- a/src/libhictk/hic/include/hictk/hic/impl/weight_cache_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/weight_cache_impl.hpp
@@ -29,6 +29,14 @@ inline auto WeightCache::find_or_emplace(const Chromosome &chrom, balancing::Met
   return find_or_emplace(chrom.id(), norm);
 }
 
+inline auto WeightCache::at(std::uint32_t chrom_id, balancing::Method norm) const -> Value {
+  return _weights.at(std::make_pair(chrom_id, norm));
+}
+
+inline auto WeightCache::at(const Chromosome &chrom, balancing::Method norm) const -> Value {
+  return at(chrom.id(), norm);
+}
+
 inline void WeightCache::clear() noexcept { _weights.clear(); }
 inline std::size_t WeightCache::size() const noexcept { return _weights.size(); }
 

--- a/src/libhictk/hic/include/hictk/hic/impl/weight_cache_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/weight_cache_impl.hpp
@@ -15,7 +15,7 @@
 
 namespace hictk::hic::internal {
 
-inline auto WeightCache::find_or_emplace(std::uint32_t chrom_id, balancing::Method norm) -> Value {
+inline auto WeightCache::get_or_init(std::uint32_t chrom_id, balancing::Method norm) -> Value {
   auto key = std::make_pair(chrom_id, norm);
   auto it = _weights.find(key);
   if (it != _weights.end()) {
@@ -25,8 +25,8 @@ inline auto WeightCache::find_or_emplace(std::uint32_t chrom_id, balancing::Meth
   return _weights.emplace(std::move(key), std::make_shared<balancing::Weights>()).first->second;
 }
 
-inline auto WeightCache::find_or_emplace(const Chromosome &chrom, balancing::Method norm) -> Value {
-  return find_or_emplace(chrom.id(), norm);
+inline auto WeightCache::get_or_init(const Chromosome &chrom, balancing::Method norm) -> Value {
+  return get_or_init(chrom.id(), norm);
 }
 
 inline auto WeightCache::at(std::uint32_t chrom_id, balancing::Method norm) const -> Value {

--- a/src/libhictk/transformers/include/hictk/transformers/common.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/common.hpp
@@ -24,6 +24,13 @@ template <typename T>
 inline constexpr bool has_coord1_member_fx<T, std::void_t<decltype(std::declval<T>().coord1())>> =
     true;
 
+template <typename T, typename = std::void_t<>>
+inline constexpr bool has_weights_member_fx = false;
+
+template <typename T>
+inline constexpr bool has_weights_member_fx<T, std::void_t<decltype(std::declval<T>().weights())>> =
+    true;
+
 template <typename N, typename PixelSelector, typename MatrixT, typename SetterOp>
 inline void fill_matrix(const PixelSelector& sel, MatrixT& buffer, std::int64_t num_rows,
                         std::int64_t num_cols, std::int64_t offset1, std::int64_t offset2,

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
@@ -193,8 +193,8 @@ ToDenseMatrix<N, PixelSelector>::slice_weights(const balancing::Weights& weights
   Eigen::Vector<N, Eigen::Dynamic> slice1(size1);
 
   for (std::int64_t i = 0; i < size1; ++i) {
-    slice1(i) = weights1.at(static_cast<std::size_t>(offset1 + i),
-                            balancing::Weights::Type::MULTIPLICATIVE);
+    slice1(i) = conditional_static_cast<N>(weights1.at(static_cast<std::size_t>(offset1 + i),
+                                                       balancing::Weights::Type::MULTIPLICATIVE));
   }
 
   const auto symmetric_query = &weights1 == &weights2 && offset1 == offset2 && size1 == size2;
@@ -204,8 +204,8 @@ ToDenseMatrix<N, PixelSelector>::slice_weights(const balancing::Weights& weights
 
   Eigen::Vector<N, Eigen::Dynamic> slice2(size2);
   for (std::int64_t i = 0; i < size2; ++i) {
-    slice2(i) = weights2.at(static_cast<std::size_t>(offset2 + i),
-                            balancing::Weights::Type::MULTIPLICATIVE);
+    slice2(i) = conditional_static_cast<N>(weights2.at(static_cast<std::size_t>(offset2 + i),
+                                                       balancing::Weights::Type::MULTIPLICATIVE));
   }
 
   return std::make_pair(std::move(slice1), std::move(slice2));

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_dense_matrix_impl.hpp
@@ -142,7 +142,7 @@ inline auto ToDenseMatrix<N, PixelSelector>::init_matrix() const -> MatrixT {
   }
 
   assert(weights2.size() != 0);
-  return weights1 * weights2.transpose() * 0;
+  return MatrixT::Zero(num_rows(), num_cols()) * weights1 * weights2.transpose();
 }
 
 template <typename N, typename PixelSelector>

--- a/src/libhictk/transformers/include/hictk/transformers/impl/to_sparse_matrix_impl.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/impl/to_sparse_matrix_impl.hpp
@@ -23,6 +23,7 @@ inline ToSparseMatrix<N, PixelSelector>::ToSparseMatrix(PixelSelector&& sel, [[m
         "hictk::transformers::ToSparseMatrix(): invalid parameters. Trans queries do not support "
         "span=QuerySpan::lower_triangle.");
   }
+  validate_dtype();
 }
 
 template <typename N, typename PixelSelector>
@@ -127,6 +128,27 @@ inline std::int64_t ToSparseMatrix<N, PixelSelector>::offset(
     const PixelCoordinates& coords) noexcept {
   constexpr auto bad_bin_id = std::numeric_limits<std::uint64_t>::max();
   return static_cast<std::int64_t>(coords.bin1.id() == bad_bin_id ? 0 : coords.bin1.id());
+}
+
+template <typename N, typename PixelSelector>
+inline void ToSparseMatrix<N, PixelSelector>::validate_dtype() const {
+  if constexpr (std::is_floating_point_v<N>) {
+    return;
+  }
+
+  constexpr auto* msg =
+      "hictk::transformers::ToSparseMatrix(): invalid parameters. n should be of floating-point "
+      "type when fetching normalized interactions.";
+
+  if constexpr (internal::has_weights_member_fx<PixelSelector>) {
+    if (!_sel.weights().is_vector_of_ones()) {
+      throw std::runtime_error(msg);
+    }
+  } else {
+    if (!_sel.weights1().is_vector_of_ones() || !_sel.weights2().is_vector_of_ones()) {
+      throw std::runtime_error(msg);
+    }
+  }
 }
 
 }  // namespace hictk::transformers

--- a/src/libhictk/transformers/include/hictk/transformers/to_dense_matrix.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_dense_matrix.hpp
@@ -48,10 +48,22 @@ class ToDenseMatrix {
   [[nodiscard]] std::int64_t row_offset() const noexcept;
   [[nodiscard]] std::int64_t col_offset() const noexcept;
 
-  void mask_bad_bins(const hictk::PixelSelector& sel, MatrixT& buffer);
-  void mask_bad_bins(const cooler::PixelSelector& sel, MatrixT& buffer);
-  void mask_bad_bins(const hic::PixelSelector& sel, MatrixT& buffer);
-  void mask_bad_bins(const hic::PixelSelectorAll& sel, MatrixT& buffer);
+  [[nodiscard]] auto init_matrix() const -> MatrixT;
+
+  [[nodiscard]] std::pair<Eigen::Vector<N, Eigen::Dynamic>, Eigen::Vector<N, Eigen::Dynamic>>
+  slice_weights(const cooler::PixelSelector& sel) const;
+  [[nodiscard]] std::pair<Eigen::Vector<N, Eigen::Dynamic>, Eigen::Vector<N, Eigen::Dynamic>>
+  slice_weights(const hic::PixelSelector& sel) const;
+  [[nodiscard]] std::pair<Eigen::Vector<N, Eigen::Dynamic>, Eigen::Vector<N, Eigen::Dynamic>>
+  slice_weights(const hic::PixelSelectorAll& sel) const;
+  [[nodiscard]] std::pair<Eigen::Vector<N, Eigen::Dynamic>, Eigen::Vector<N, Eigen::Dynamic>>
+  slice_weights(const hictk::PixelSelector& sel) const;
+
+  [[nodiscard]] static std::pair<Eigen::Vector<N, Eigen::Dynamic>, Eigen::Vector<N, Eigen::Dynamic>>
+  slice_weights(const balancing::Weights& weights1, const balancing::Weights& weights2,
+                std::int64_t offset1, std::int64_t offset2, std::int64_t size1, std::int64_t size2);
+
+  void validate_dtype() const;
 };
 
 }  // namespace hictk::transformers

--- a/src/libhictk/transformers/include/hictk/transformers/to_sparse_matrix.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_sparse_matrix.hpp
@@ -42,6 +42,8 @@ class ToSparseMatrix {
   [[nodiscard]] static std::int64_t offset(const PixelCoordinates& coords) noexcept;
   [[nodiscard]] std::int64_t row_offset() const noexcept;
   [[nodiscard]] std::int64_t col_offset() const noexcept;
+
+  void validate_dtype() const;
 };
 
 }  // namespace hictk::transformers


### PR DESCRIPTION
This PR addresses a bug detected by the new fuzzer suite.
In brief, fetching normalized pixels as dense matrices could sometime results in incorrect results, where some entries that were supposed to be inf (due to e.g. normalization with divisive weights of value 0) were instead set to nan.