### PR TITLE
Fix temporary file name collisions in hictk convert *cool -> hic

### DIFF
--- a/src/hictk/convert/cool_to_hic.cpp
+++ b/src/hictk/convert/cool_to_hic.cpp
@@ -16,6 +16,7 @@
 #include "hictk/cooler/cooler.hpp"
 #include "hictk/cooler/multires_cooler.hpp"
 #include "hictk/hic/file_writer.hpp"
+#include "hictk/tmpdir.hpp"
 #include "hictk/tools/config.hpp"
 
 namespace hictk::tools {
@@ -102,7 +103,7 @@ static void copy_normalization_vectors(hic::internal::HiCFileWriter& w,
 void cool_to_hic(const ConvertConfig& c) {
   if (c.force && std::filesystem::exists(c.path_to_output)) {
     [[maybe_unused]] std::error_code ec{};
-    std::filesystem::remove(c.path_to_output, ec);
+    std::filesystem::remove(c.path_to_output, ec);  // NOLINT
   }
 
   const auto base_uri = c.input_format == "cool"
@@ -120,7 +121,7 @@ void cool_to_hic(const ConvertConfig& c) {
 
   const internal::TmpDir tmpdir{c.tmp_dir, true};
   hictk::hic::internal::HiCFileWriter w(c.path_to_output.string(), chromosomes, resolutions,
-                                        c.genome, c.threads, c.chunk_size, c.tmp_dir,
+                                        c.genome, c.threads, c.chunk_size, tmpdir(),
                                         c.compression_lvl, c.skip_all_vs_all_matrix);
   copy_pixels(w, base_clr, c);
   w.serialize();

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -141,6 +141,9 @@ inline HiCInteractionToBlockMapper::HiCInteractionToBlockMapper(
       _zstd_cctx(ZSTD_createCCtx()),
       _zstd_dctx(ZSTD_createDCtx()) {
   assert(_chunk_size != 0);
+  SPDLOG_INFO(
+      FMT_STRING("initializing HiCInteractionToBlockMapper using \"{}\" as temporary file..."),
+      _path);
   init_block_mappers();
 }
 


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/paulsengroup/hictk/issues/271.

This bug is a regression introduced by https://github.com/paulsengroup/hictk/pull/210.

In brief, when performing *cool -> hic conversion, a randomly-named, self-deleting temporary directory was created under the default temporary directory (e.g. `/tmp`) or a user provided temporary folder.
However, due to a silly mistake, the __parent__ of this folder was passed to one of the functions creating temporary files. When converting multiple files sharing one or more resolution in parallel using the default temporary folder, this results in unintended file truncation (which could lead to all kinds of errors).

Other commands creating .hic files (e.g. `hictk load` and `hictk zoomify`) are not affected.