### PR TITLE
Refactor FileStream and HiCFileWriter to be more robust against data races

### DIFF
--- a/src/hictk/CMakeLists.txt
+++ b/src/hictk/CMakeLists.txt
@@ -64,6 +64,8 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/zoomify/mcool.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/zoomify/zoomify.cpp)
 
+target_compile_definitions(hictk PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+
 target_include_directories(hictk PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(hictk PRIVATE hictk_project_options hictk_project_warnings hictk::libhictk)
 

--- a/src/hictk/CMakeLists.txt
+++ b/src/hictk/CMakeLists.txt
@@ -64,8 +64,6 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/zoomify/mcool.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/zoomify/zoomify.cpp)
 
-target_compile_definitions(hictk PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
-
 target_include_directories(hictk PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(hictk PRIVATE hictk_project_options hictk_project_warnings hictk::libhictk)
 

--- a/src/hictk/main.cpp
+++ b/src/hictk/main.cpp
@@ -35,9 +35,9 @@ static void setup_logger_console() {
   spdlog::set_default_logger(main_logger);
 }
 
-static void setup_logger_console(int verbosity_lvl, bool print_version) {
+static void setup_logger_console([[maybe_unused]] int verbosity_lvl, bool print_version) {
   for (auto& sink : spdlog::default_logger()->sinks()) {
-    sink->set_level(spdlog::level::level_enum(verbosity_lvl));
+    sink->set_level(spdlog::level::debug);
   }
 
   if (print_version) {

--- a/src/hictk/main.cpp
+++ b/src/hictk/main.cpp
@@ -35,9 +35,9 @@ static void setup_logger_console() {
   spdlog::set_default_logger(main_logger);
 }
 
-static void setup_logger_console([[maybe_unused]] int verbosity_lvl, bool print_version) {
+static void setup_logger_console(int verbosity_lvl, bool print_version) {
   for (auto& sink : spdlog::default_logger()->sinks()) {
-    sink->set_level(spdlog::level::debug);
+    sink->set_level(spdlog::level::level_enum(verbosity_lvl));
   }
 
   if (print_version) {

--- a/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
@@ -128,9 +128,9 @@ class SparseMatrix {
   void push_back(std::uint64_t bin1_id, std::uint64_t bin2_id, double count,
                  std::size_t bin_offset = 0);
 
-  void serialize(filestream::FileStream& fs, std::string& tmpbuff, ZSTD_CCtx& ctx,
+  void serialize(filestream::FileStream<>& fs, std::string& tmpbuff, ZSTD_CCtx& ctx,
                  int compression_lvl = 3) const;
-  void deserialize(filestream::FileStream& fs, std::string& tmpbuff, ZSTD_DCtx& ctx);
+  void deserialize(filestream::FileStream<>& fs, std::string& tmpbuff, ZSTD_DCtx& ctx);
 
   void marginalize(VectorOfAtomicDecimals& marg, bool init_buffer = true) const;
   void marginalize_nnz(VectorOfAtomicDecimals& marg, bool init_buffer = true) const;
@@ -180,9 +180,9 @@ class FileBackedSparseMatrix {
   mutable SparseMatrix _matrix{};
   mutable std::string _buff{};
   std::filesystem::path _path{};
-  mutable filestream::FileStream _fs{};
+  mutable filestream::FileStream<> _fs{};
 
-  std::vector<std::size_t> _index{};
+  std::vector<std::streampos> _index{};
   std::size_t _size{};
   std::size_t _chunk_size{};
   int _compression_lvl{};

--- a/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -20,20 +21,20 @@ class BinaryBuffer {
   BinaryBuffer() = default;
 
   // NOLINTNEXTLINE
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   T read();
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void read(T& buff);
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void read(std::vector<T>& buff);
   void read(std::string& buff, std::size_t n);
   void read(char* buff, std::size_t n);
   std::string getline(char delim = '\n');
   // NOLINTNEXTLINE
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void write(T data);
   void write(const std::string& data, bool add_nullterm = true);
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void write(const std::vector<T>& data);
 
   // Return the offset of the underlying buffer. Useful for error checking

--- a/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
@@ -14,6 +14,10 @@
 namespace hictk {
 
 class BinaryBuffer {
+  static_assert(sizeof(char) == 1);
+  static_assert(sizeof(float) == 4);
+  static_assert(sizeof(double) == 8);
+
   std::string _buffer{};
   std::size_t _i{};
 
@@ -30,7 +34,8 @@ class BinaryBuffer {
   void read(std::string& buff, std::size_t n);
   void read(char* buff, std::size_t n);
   std::string getline(char delim = '\n');
-  // NOLINTNEXTLINE
+
+  void write(const char* data, std::size_t count, bool add_nullterm = false);
   template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void write(T data);
   void write(const std::string& data, bool add_nullterm = true);

--- a/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
@@ -11,7 +11,7 @@
 
 namespace hictk {
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline T BinaryBuffer::read() {
   static_assert(sizeof(char) == 1);
   assert(_i < _buffer.size());
@@ -22,12 +22,12 @@ inline T BinaryBuffer::read() {
   return x;
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::read(T &buff) {
   buff = read<T>();
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::read(std::vector<T> &buff) {
   read(reinterpret_cast<char *>(buff.data()), sizeof(T) * buff.size());
 }
@@ -51,7 +51,7 @@ inline std::string BinaryBuffer::getline(char delim) {
   return std::string{view.substr(0, pos)};
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::write(T data) {
   static_assert(sizeof(char) == 1);
   _buffer.append(reinterpret_cast<const char *>(&data), sizeof(T));
@@ -61,7 +61,7 @@ inline void BinaryBuffer::write(const std::string &data, bool add_nullterm) {
   _buffer.append(data.c_str(), data.size() + add_nullterm);
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 void BinaryBuffer::write(const std::vector<T> &data) {
   _buffer.append(reinterpret_cast<const char *>(data.data()), data.size() * sizeof(T));
 }

--- a/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
@@ -51,19 +51,25 @@ inline std::string BinaryBuffer::getline(char delim) {
   return std::string{view.substr(0, pos)};
 }
 
+inline void BinaryBuffer::write(const char *data, std::size_t count, bool add_nullterm) {
+  _buffer.append(data, count);
+  if (add_nullterm) {
+    _buffer.append("\0", 1);
+  }
+}
+
 template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::write(T data) {
-  static_assert(sizeof(char) == 1);
-  _buffer.append(reinterpret_cast<const char *>(&data), sizeof(T));
+  write(reinterpret_cast<const char *>(&data), sizeof(T), false);
 }
 
 inline void BinaryBuffer::write(const std::string &data, bool add_nullterm) {
-  _buffer.append(data.c_str(), data.size() + add_nullterm);
+  write(data.c_str(), data.size() + add_nullterm, false);
 }
 
 template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 void BinaryBuffer::write(const std::vector<T> &data) {
-  _buffer.append(reinterpret_cast<const char *>(data.data()), data.size() * sizeof(T));
+  write(reinterpret_cast<const char *>(data.data()), data.size() * sizeof(T), false);
 }
 
 inline std::size_t BinaryBuffer::operator()() const noexcept { return _i; }

--- a/src/libhictk/common/include/hictk/static_binary_buffer.hpp
+++ b/src/libhictk/common/include/hictk/static_binary_buffer.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+
+namespace hictk::internal {
+
+template <typename... Ts>
+class StaticBinaryBuffer {
+  static_assert((std::is_arithmetic_v<Ts> && ...), "Not all types are arithmetic!");
+
+  // We are allocating one extra byte so that we can store '\0' as the last value
+  // (just in case the string_view returned by operator()() is passed to some function
+  // that expects null-terminated strings)
+  static constexpr std::size_t SIZE = (sizeof(Ts) + ... + 1);
+
+  alignas(std::uint64_t) std::array<char, SIZE> _buff{'\0'};
+
+ public:
+  StaticBinaryBuffer() = default;
+  inline explicit StaticBinaryBuffer(const Ts &...inputs) noexcept {
+    std::size_t i = 0;
+    (
+        [&] {
+          // This is just a best-effort attempt to make the compiler do the data copying at compile
+          // time.
+          // When this fails, and the copying is done at run time, this implementation will be much
+          // slower than e.g. std::memcopy.
+          // However, StaticBinaryBuffer should never be used to more than say a few dozens of bytes
+          // worth of data, so even if the data copying ends up being slow, it shouldn't be a big
+          // deal.
+          const auto *src = reinterpret_cast<const char *>(&inputs);
+          for (std::size_t j = 0; j < sizeof(inputs); ++j, ++i) {
+            _buff[i] = *(src + j);
+          }
+        }(),
+        ...);
+
+    assert(!_buff.empty());
+    _buff.back() = '\0';
+  }
+
+  constexpr std::string_view operator()() const noexcept {
+    return std::string_view{_buff.data(), _buff.size() - 1};
+  }
+};
+
+}  // namespace hictk::internal

--- a/src/libhictk/common/include/hictk/type_traits.hpp
+++ b/src/libhictk/common/include/hictk/type_traits.hpp
@@ -28,6 +28,16 @@ struct is_string
 template <typename T>
 constexpr bool is_string_v = is_string<T>::value;
 
+// Note that this will not work for types with non-type template arguments (e.g. std::array)
+template <typename T, template <typename...> typename Template>
+struct is_specialization : std::false_type {};
+
+template <template <typename...> typename Template, typename... Args>
+struct is_specialization<Template<Args...>, Template> : std::true_type {};
+
+template <typename T, template <typename...> typename Template>
+constexpr bool is_specialization_v = is_specialization<T, Template>::value;
+
 template <typename T, typename Enabler = void>
 struct is_map : std::false_type {};
 

--- a/src/libhictk/cooler/include/hictk/cooler/impl/utils_copy_impl.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/impl/utils_copy_impl.hpp
@@ -29,12 +29,12 @@
 namespace hictk::cooler::utils {
 
 inline void copy(std::string_view uri1, std::string_view uri2) {
-  const auto [path2, grp2] = cooler::parse_cooler_uri(uri2);
+  const auto uri = cooler::parse_cooler_uri(uri2);
   if (std::filesystem::exists(uri2) && utils::is_cooler(uri2)) {
     throw std::runtime_error("destination already contains a Cooler");
   }
-  const HighFive::File dest(path2, HighFive::File::OpenOrCreate);
-  return copy(uri1, RootGroup{dest.getGroup(grp2)});
+  const HighFive::File dest(uri.file_path, HighFive::File::OpenOrCreate);
+  return copy(uri1, RootGroup{dest.getGroup(uri.group_path)});
 }
 
 inline void copy(std::string_view uri1, RootGroup dest) {
@@ -46,8 +46,8 @@ inline void copy(std::string_view uri1, RootGroup dest) {
     /* Attempt to open an existing HDF5 file first. Need to open the dst file
          before the src file just in case that the dst and src are the same file
     */
-    const auto [path1, grp1] = cooler::parse_cooler_uri(uri1);
-    const HighFive::File fin(path1, HighFive::File::ReadOnly);
+    const auto uri = cooler::parse_cooler_uri(uri1);
+    const HighFive::File fin(uri.file_path, HighFive::File::ReadOnly);
 
     /* create property to pass copy options */
     auto ocpl_id = H5Pcreate(H5P_OBJECT_COPY);
@@ -96,12 +96,12 @@ inline void copy(std::string_view uri1, RootGroup dest) {
       }
     };
 
-    for (const auto &obj : fin.getGroup(grp1).listObjectNames()) {
-      copy_h5_object(fin.getGroup(grp1), dest(), obj);
+    for (const auto &obj : fin.getGroup(uri.group_path).listObjectNames()) {
+      copy_h5_object(fin.getGroup(uri.group_path), dest(), obj);
     }
 
-    for (const auto &attr : fin.getGroup(grp1).listAttributeNames()) {
-      copy_h5_attribute(fin.getGroup(grp1), dest(), std::string{attr});
+    for (const auto &attr : fin.getGroup(uri.group_path).listAttributeNames()) {
+      copy_h5_attribute(fin.getGroup(uri.group_path), dest(), std::string{attr});
     }
 
     /* close propertis */

--- a/src/libhictk/filestream/include/hictk/filestream.hpp
+++ b/src/libhictk/filestream/include/hictk/filestream.hpp
@@ -41,12 +41,12 @@ class FileStream {
   static FileStream create(std::string path, std::shared_ptr<Mutex> mtx);
 
   FileStream(const FileStream &other) = delete;
-  FileStream(FileStream &&other) noexcept = default;
+  FileStream(FileStream &&other) noexcept;
 
   ~FileStream() noexcept = default;
 
   FileStream &operator=(const FileStream &other) = delete;
-  FileStream &operator=(FileStream &&other) noexcept = default;
+  FileStream &operator=(FileStream &&other) noexcept;
 
   [[nodiscard]] const std::string &path() const noexcept;
 

--- a/src/libhictk/filestream/include/hictk/filestream.hpp
+++ b/src/libhictk/filestream/include/hictk/filestream.hpp
@@ -8,90 +8,185 @@
 #include <fstream>
 #include <ios>
 #include <iosfwd>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace hictk::filestream {
 
+template <typename Mutex = std::mutex>
 class FileStream {
+  static_assert(sizeof(char) == 1, "char must be 1 byte wide!");
+  static_assert(sizeof(float) == 4, "float must be 4 bytes wide!");
+  static_assert(sizeof(double) == 8, "double must be 8 bytes wide!");
   std::string _path{};
+  mutable std::shared_ptr<Mutex> _mtx{};
   mutable std::ifstream _ifs{};
   mutable std::ofstream _ofs{};
-  std::size_t _file_size{};
+  std::streamsize _file_size{};
 
  public:
   FileStream() = default;
-  explicit FileStream(std::string path, std::ios::openmode mode = std::ios::in);
-  static FileStream create(std::string path);
+  // pass nullptr as mtx to disable file locking
+  FileStream(std::string path, std::shared_ptr<Mutex> mtx, std::ios::openmode mode = std::ios::in);
+  static FileStream create(std::string path, std::shared_ptr<Mutex> mtx);
+
+  FileStream(const FileStream &other) = delete;
+  FileStream(FileStream &&other) noexcept = default;
+
+  ~FileStream() noexcept = default;
+
+  FileStream &operator=(const FileStream &other) = delete;
+  FileStream &operator=(FileStream &&other) noexcept = default;
 
   [[nodiscard]] const std::string &path() const noexcept;
-  [[nodiscard]] std::size_t size() const;
+
+  // seek*
+  void seekg(std::streampos position);
+  void unsafe_seekg(std::streampos position);
+  void seekp(std::streampos position);
+  void unsafe_seekp(std::streampos position);
 
   void seekg(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
-  [[nodiscard]] std::size_t tellg() const noexcept;
-
+  void unsafe_seekg(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
   void seekp(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
-  [[nodiscard]] std::size_t tellp() const noexcept;
+  void unsafe_seekp(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
 
-  [[nodiscard]] bool eof() const noexcept;
+  // tell*
+  [[nodiscard]] std::streampos tellg() const;
+  [[nodiscard]] std::streampos unsafe_tellg() const;
+  [[nodiscard]] std::streampos tellp() const;
+  [[nodiscard]] std::streampos unsafe_tellp() const;
+
+  // others
+  [[nodiscard]] std::streamsize size() const;
+  [[nodiscard]] std::streamsize unsafe_size() const;
+
+  [[nodiscard]] bool eof() const;
+  [[nodiscard]] bool unsafe_eof() const;
 
   void flush();
+  void unsafe_flush();
 
-  void read(std::string &buffer, std::size_t count);
+  [[nodiscard]] static std::string get_underlying_os_error();
+
+  // Locks mutex protecting the underlying file streams.
+  // IMPORTANT: while the lock is held, only unsafe_* methods can be used.
+  [[nodiscard]] std::unique_lock<Mutex> lock() const;
+  [[nodiscard]] bool is_locked() const noexcept;
+
+  // read char*
   void read(char *buffer, std::size_t count);
-  void read_append(std::string &buffer, std::size_t count);
+  // this method (as well as all other seek_* methods) return a pair with the offset before seek and
+  // the offset after read/write
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset, char *buffer,
+                                                          std::size_t count,
+                                                          std::ios::seekdir way = std::ios::beg);
+  void unsafe_read(char *buffer, std::size_t count);
 
+  // read std::string
+  [[nodiscard]] std::string read(std::size_t count);
+  void read(std::string &buffer, std::size_t count);
+  void read_append(std::string &buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset,
+                                                          std::string &buffer, std::size_t count,
+                                                          std::ios::seekdir way = std::ios::beg);
+
+  // getline
   bool getline(std::string &buffer, char delim = '\n');
   [[nodiscard]] std::string getline(char delim = '\n');
+  std::tuple<bool, std::streampos, std::streampos> seek_and_getline(
+      std::streamoff offset, std::string &buffer, std::ios::seekdir way = std::ios::beg,
+      char delim = '\n');
+  bool unsafe_getline(std::string &buffer, char delim);
 
-  void write(std::string_view buffer);
-  void write(const char *buffer, std::size_t count);
-
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // read T
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   [[nodiscard]] T read();
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void read(T &buffer);
-
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
-  void write(T buffer);
-
-  template <typename Tin,
-            typename Tout = std::make_signed_t<Tin>,  // NOLINTNEXTLINE(modernize-type-traits)
-            typename std::enable_if<std::is_integral<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename Tout = std::make_signed_t<Tin>,
+            typename std::enable_if_t<std::is_integral_v<Tin>> * = nullptr>
   [[nodiscard]] Tout read_as_signed();
-  template <typename Tin,
-            typename Tout = std::make_unsigned_t<Tin>,  // NOLINTNEXTLINE(modernize-type-traits)
-            typename std::enable_if<std::is_integral<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename Tout = std::make_unsigned_t<Tin>,
+            typename std::enable_if_t<std::is_integral_v<Tin>> * = nullptr>
   [[nodiscard]] Tout read_as_unsigned();
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename Tin, typename std::enable_if<std::is_arithmetic<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename std::enable_if_t<std::is_arithmetic_v<Tin>> * = nullptr>
   [[nodiscard]] double read_as_double();
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_read(T &buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  [[nodiscard]] T unsafe_read();
 
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // read vector<T>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void read(std::vector<T> &buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  [[nodiscard]] std::vector<T> read_vector(std::size_t size);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset,
+                                                          std::vector<T> &buffer,
+                                                          std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_read(std::vector<T> &buffer);
 
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // write const char*
+  void write(const char *buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           const char *buffer, std::size_t count,
+                                                           std::ios::seekdir way = std::ios::beg);
+  void unsafe_write(const char *buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> append(const char *buffer, std::size_t count);
+
+  // write std::string
+  void write(std::string_view buffer);
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           std::string_view buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  std::pair<std::streampos, std::streampos> append(std::string_view buffer);
+
+  // write T
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void write(T buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_write(T buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset, T buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> append(T buffer);
+
+  // write vector<T>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void write(const std::vector<T> &buffer);
-
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
-  [[nodiscard]] std::vector<T> read(std::size_t size);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           const std::vector<T> &buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> append(const std::vector<T> &buffer);
 
  private:
   [[nodiscard]] std::streampos new_posg(std::streamoff offset, std::ios::seekdir way);
+  [[nodiscard]] std::streampos new_posg_checked(std::streamoff offset, std::ios::seekdir way);
   [[nodiscard]] std::streampos new_posp(std::streamoff offset, std::ios::seekdir way);
   void update_file_size();
+  void unsafe_update_file_size();
   [[nodiscard]] static std::ifstream open_file_read(const std::string &path,
                                                     std::ifstream::openmode mode);
   [[nodiscard]] static std::ofstream open_file_write(const std::string &path,
                                                      std::ofstream::openmode mode);
+  [[nodiscard]] static std::string get_underlying_os_error(int errno_);
+  static void get_underlying_os_error(int errno_, std::string &buffer);
+
+  template <typename T, typename I1, typename I2>
+  static void validate_read(I1 bytes_read, I2 count_expected,
+                            std::string_view prefix = "FileStream::read*()");
 };
 }  // namespace hictk::filestream
 

--- a/src/libhictk/filestream/include/hictk/filestream.hpp
+++ b/src/libhictk/filestream/include/hictk/filestream.hpp
@@ -24,11 +24,15 @@ class FileStream {
   static_assert(sizeof(char) == 1, "char must be 1 byte wide!");
   static_assert(sizeof(float) == 4, "float must be 4 bytes wide!");
   static_assert(sizeof(double) == 8, "double must be 8 bytes wide!");
+
   std::string _path{};
   mutable std::shared_ptr<Mutex> _mtx{};
   mutable std::ifstream _ifs{};
   mutable std::ofstream _ofs{};
   std::streamsize _file_size{};
+
+  static const std::ifstream::openmode _ifs_flags{std::ios::in | std::ios::binary};
+  static const std::ofstream::openmode _ofs_flags{std::ios::in | std::ios::out | std::ios::binary};
 
  public:
   FileStream() = default;
@@ -170,6 +174,8 @@ class FileStream {
                                                            std::ios::seekdir way = std::ios::beg);
   template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   std::pair<std::streampos, std::streampos> append(const std::vector<T> &buffer);
+
+  void resize(std::streamsize new_size);
 
  private:
   [[nodiscard]] std::streampos new_posg(std::streamoff offset, std::ios::seekdir way);

--- a/src/libhictk/filestream/include/hictk/filestream.hpp
+++ b/src/libhictk/filestream/include/hictk/filestream.hpp
@@ -50,6 +50,8 @@ class FileStream {
 
   [[nodiscard]] const std::string &path() const noexcept;
 
+  void close();
+
   // seek*
   void seekg(std::streampos position);
   void unsafe_seekg(std::streampos position);

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -656,10 +656,10 @@ inline void FileStream<Mutex>::get_underlying_os_error([[maybe_unused]] int errn
 #if defined(_GNU_SOURCE)
   buffer = strerror_r(errno_, buffer.data(), buffer.size());
 #elif defined(_WIN32)
-  buffer.resize(std::max(buffer.capacity(), 1024), '\0');
+  buffer.resize(std::max(buffer.capacity(), std::size_t{1024}), '\0');
   const int status = strerror_s(buffer.data(), buffer.size(), errno_);
 #else
-  buffer.resize(std::max(buffer.capacity(), 1024), '\0');
+  buffer.resize(std::max(buffer.capacity(), std::size_t{1024}), '\0');
   const int status = strerror_r(errno_, buffer.data(), buffer.size());
 #endif
 

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -40,7 +40,7 @@ inline FileStream<Mutex>::FileStream(std::string path, std::shared_ptr<Mutex> mt
       _ofs(mode & std::ios::out
                ? open_file_write(_path, std::ios::in | std::ios::out | std::ios::binary)
                : std::ofstream{}),
-      _file_size(_ifs.tellg()) {
+      _file_size(unsafe_tellg()) {
   unsafe_seekg(0);
 }
 
@@ -104,7 +104,9 @@ inline void FileStream<Mutex>::seekp(std::streamoff offset, std::ios::seekdir wa
 
 template <typename Mutex>
 inline void FileStream<Mutex>::unsafe_seekp(std::streamoff offset, std::ios::seekdir way) {
-  _ofs.seekp(new_posp(offset, way), std::ios::beg);
+  const auto pos = new_posp(offset, way);
+  _ofs.seekp(pos, std::ios::beg);
+  _file_size = std::max(static_cast<std::streamsize>(pos), _file_size);
 }
 
 template <typename Mutex>

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -94,6 +94,20 @@ inline const std::string &FileStream<Mutex>::path() const noexcept {
 }
 
 template <typename Mutex>
+inline void FileStream<Mutex>::close() {
+  {
+    [[maybe_unused]] const auto lck = lock();
+    if (_ifs.is_open()) {
+      _ifs.close();
+    }
+    if (_ofs.is_open()) {
+      _ofs.close();
+    }
+  }
+  _mtx.reset();
+}
+
+template <typename Mutex>
 inline void FileStream<Mutex>::seekg(std::streampos position) {
   seekg(position, std::ios::beg);
 }

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -5,8 +5,10 @@
 #pragma once
 
 #ifdef _WIN32
-#include <errhandlingapi.h>
+// clang-format off
 #include <windows.h>
+#include <errhandlingapi.h>
+// clang-format on
 #endif
 
 #include <cassert>

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -227,7 +227,9 @@ inline bool FileStream<Mutex>::is_locked() const noexcept {
   if (!_mtx) {
     return false;
   }
-  return !std::unique_lock(*_mtx, std::try_to_lock).owns_lock();
+  // clang8 complains if this expression is written in a single line
+  const std::unique_lock lck{*_mtx, std::try_to_lock};
+  return !lck.owns_lock();
 }
 
 template <typename Mutex>

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -227,7 +227,7 @@ inline bool FileStream<Mutex>::is_locked() const noexcept {
   if (!_mtx) {
     return false;
   }
-  return !std::unique_lock{*_mtx, std::try_to_lock}.owns_lock();
+  return !std::unique_lock(*_mtx, std::try_to_lock).owns_lock();
 }
 
 template <typename Mutex>

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -57,6 +57,31 @@ inline FileStream<Mutex> FileStream<Mutex>::create(std::string path, std::shared
   return fs;
 }
 
+// We need to explicitly define the move constructor to make things compile on older compilers
+// (where std::mutex is not moveable)
+template <typename Mutex>
+inline FileStream<Mutex>::FileStream(FileStream &&other) noexcept
+    : _path(std::move(other._path)),
+      _ifs(std::move(other._ifs)),
+      _ofs(std::move(other._ofs)),
+      _file_size(other._file_size) {}
+
+// We need to explicitly define the move assignment operator to make things compile on older
+// compilers (where std::mutex is not moveable)
+template <typename Mutex>
+inline FileStream<Mutex> &FileStream<Mutex>::operator=(FileStream &&other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  _path = std::move(other._path);
+  _ifs = std::move(other._ifs);
+  _ofs = std::move(other._ofs);
+  _file_size = other._file_size;
+
+  return *this;
+}
+
 template <typename Mutex>
 inline const std::string &FileStream<Mutex>::path() const noexcept {
   return _path;

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -4,232 +4,652 @@
 
 #pragma once
 
+#ifdef _WIN32
+#include <errhandlingapi.h>
+#endif
 #include <cassert>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iosfwd>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "hictk/common.hpp"
+#include "hictk/type_traits.hpp"
 
 namespace hictk::filestream {
 
-inline FileStream::FileStream(std::string path, std::ios::openmode mode)
+template <typename Mutex>
+inline FileStream<Mutex>::FileStream(std::string path, std::shared_ptr<Mutex> mtx,
+                                     std::ios::openmode mode)
     : _path(std::move(path)),
+      _mtx(std::move(mtx)),
       _ifs(open_file_read(_path, std::ios::in | std::ios::binary | std::ios::ate)),
       _ofs(mode & std::ios::out
                ? open_file_write(_path, std::ios::in | std::ios::out | std::ios::binary)
                : std::ofstream{}),
-      _file_size(static_cast<std::size_t>(_ifs.tellg())) {
-  _ifs.seekg(0, std::ios::beg);
+      _file_size(_ifs.tellg()) {
+  unsafe_seekg(0);
 }
 
-inline FileStream FileStream::create(std::string path) {
+template <typename Mutex>
+inline FileStream<Mutex> FileStream<Mutex>::create(std::string path, std::shared_ptr<Mutex> mtx) {
   if (std::filesystem::exists(path)) {
     throw std::runtime_error("file \"" + path + "\" already exists");
   }
+
   FileStream fs{};
   fs._path = std::move(path);
+  fs._mtx = std::move(mtx);
   fs._ofs = open_file_write(fs._path, std::ios::trunc | std::ios::binary);
   fs._ifs = open_file_read(fs._path, std::ios::binary);
 
   return fs;
 }
 
-inline const std::string &FileStream::path() const noexcept { return _path; }
+template <typename Mutex>
+inline const std::string &FileStream<Mutex>::path() const noexcept {
+  return _path;
+}
 
-inline std::size_t FileStream::size() const { return _file_size; }
+template <typename Mutex>
+inline void FileStream<Mutex>::seekg(std::streampos position) {
+  seekg(position, std::ios::beg);
+}
 
-inline void FileStream::seekg(std::streamoff offset, std::ios::seekdir way) {
-  const auto new_pos = new_posg(offset, way);
-  if (new_pos < 0 || new_pos >= std::int64_t(size() + 1)) {
-    throw std::runtime_error("caught an attempt of out-of-bound read");
-  }
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekg(std::streampos position) {
+  unsafe_seekg(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::seekp(std::streampos position) {
+  seekp(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekp(std::streampos position) {
+  unsafe_seekp(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::seekg(std::streamoff offset, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_seekg(offset, way);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekg(std::streamoff offset, std::ios::seekdir way) {
+  const auto new_pos = new_posg_checked(offset, way);
   _ifs.seekg(new_pos, std::ios::beg);
 }
 
-inline std::size_t FileStream::tellg() const noexcept {
-  assert(_ifs.tellg() >= 0);
-  return static_cast<std::size_t>(_ifs.tellg());
+template <typename Mutex>
+inline void FileStream<Mutex>::seekp(std::streamoff offset, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_seekp(offset, way);
 }
 
-inline void FileStream::seekp(std::streamoff offset, std::ios::seekdir way) {
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekp(std::streamoff offset, std::ios::seekdir way) {
   _ofs.seekp(new_posp(offset, way), std::ios::beg);
 }
 
-inline std::size_t FileStream::tellp() const noexcept {
-  assert(_ofs.tellp() >= 0);
-  return static_cast<std::size_t>(_ofs.tellp());
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::tellg() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_tellg();
 }
 
-inline bool FileStream::eof() const noexcept { return _ifs.eof(); }
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::unsafe_tellg() const {
+  const auto offset = _ifs.tellg();
+  if (offset >= 0) {
+    return offset;
+  }
+  throw std::runtime_error("FileStream::tellg() called on a bad file handle: " +
+                           get_underlying_os_error());
+}
 
-inline void FileStream::flush() { _ofs.flush(); }
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::tellp() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_tellp();
+}
 
-inline void FileStream::read(std::string &buffer, std::size_t count) {
-  buffer.resize(count);
-  if (count > 0) {
-    return read(&buffer.front(), count);
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::unsafe_tellp() const {
+  const auto offset = _ofs.tellp();
+  if (offset >= 0) {
+    return offset;
+  }
+  throw std::runtime_error("FileStream::tellp() called on a bad file handle: " +
+                           get_underlying_os_error());
+}
+
+template <typename Mutex>
+inline std::streamsize FileStream<Mutex>::size() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_size();
+}
+
+template <typename Mutex>
+inline std::streamsize FileStream<Mutex>::unsafe_size() const {
+  if constexpr (ndebug_not_defined()) {
+    if (path().empty()) {
+      return _file_size;
+    }
+    _ofs.flush();
+    const auto offset = unsafe_tellg();
+    _ifs.seekg(0, std::ios::end);
+    const auto effective_size = unsafe_tellg();
+    _ifs.seekg(offset, std::ios::beg);
+    if (effective_size != _file_size) {
+      throw std::runtime_error("FileStream is corrupted: expected size " +
+                               std::to_string(_file_size) + ", found " +
+                               std::to_string(effective_size));
+    }
+  }
+  return _file_size;
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::eof() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_eof();
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::unsafe_eof() const {
+  return _ifs.eof();
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::flush() {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_flush();
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_flush() {
+  _ofs.flush();
+}
+
+template <typename Mutex>
+inline std::unique_lock<Mutex> FileStream<Mutex>::lock() const {
+  if (!_mtx) {
+    return {};
+  }
+  return std::unique_lock{*_mtx};
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::is_locked() const noexcept {
+  if (!_mtx) {
+    return false;
+  }
+  return !std::unique_lock{*_mtx, std::try_lock}.owns_lock();
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::read(std::size_t count) {
+  std::string buffer(count, '\0');
+  read(buffer, count);
+  return buffer;
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::read(char *buffer, std::size_t count) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_read(buffer, count);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, char *buffer, std::size_t count, std::ios::seekdir way) {
+  auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  unsafe_read(buffer, count);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_read(char *buffer, std::size_t count) {
+  const auto offset1 = unsafe_tellg();
+  _ifs.read(buffer, static_cast<std::streamsize>(count));
+  const auto bytes_read = unsafe_tellg() - offset1;
+  validate_read<char>(bytes_read, count, "FileStream::unsafe_read(char *)");
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::read(std::string &buffer, std::size_t count) {
+  try {
+    buffer.resize(count);
+    if (count == 0) {
+      return;
+    }
+    read(&buffer.front(), count);
+  } catch (...) {
+    buffer.clear();
+    throw;
   }
 }
 
-inline void FileStream::read(char *buffer, std::size_t count) {
-  _ifs.read(buffer, std::int64_t(count));
-}
-
-inline void FileStream::read_append(std::string &buffer, std::size_t count) {
+template <typename Mutex>
+inline void FileStream<Mutex>::read_append(std::string &buffer, std::size_t count) {
   if (count == 0) {
     return;
   }
-  const auto buff_size = buffer.size();
-  buffer.resize(buffer.size() + count);
 
-  _ifs.read(&(*buffer.begin()) + buff_size, std::int64_t(count));
+  const auto buff_size = buffer.size();
+  try {
+    buffer.resize(buffer.size() + count);
+
+    [[maybe_unused]] const auto lck = lock();
+    const auto offset1 = unsafe_tellg();
+    _ifs.read(&(*buffer.begin()) + buff_size, static_cast<std::streamsize>(count));
+    const auto bytes_read = static_cast<std::size_t>(unsafe_tellg() - offset1);
+    validate_read<char>(bytes_read, count, "FileStream::read_append(std::string &)");
+  } catch (...) {
+    buffer.resize(buff_size);
+    throw;
+  }
 }
 
-inline bool FileStream::getline(std::string &buffer, char delim) {
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, std::string &buffer, std::size_t count, std::ios::seekdir way) {
+  try {
+    buffer.resize(count);
+    return seek_and_read(offset, buffer.data(), buffer.size(), way);
+  } catch (...) {
+    buffer.clear();
+    throw;
+  }
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::getline(std::string &buffer, char delim) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_getline(buffer, delim);
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::getline(char delim) {
+  std::string buffer{};
+  getline(buffer, delim);
+  return buffer;
+}
+
+template <typename Mutex>
+inline std::tuple<bool, std::streampos, std::streampos> FileStream<Mutex>::seek_and_getline(
+    std::streamoff offset, std::string &buffer, std::ios::seekdir way, char delim) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  const auto status = unsafe_getline(buffer, delim);
+  return std::make_tuple(status, offset1, unsafe_tellg());
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::unsafe_getline(std::string &buffer, char delim) {
   buffer.clear();
-  if (eof()) {
+  if (unsafe_eof()) {
     _ifs.setstate(std::ios::badbit);
   }
   try {
     return !!std::getline(_ifs, buffer, delim);
-  } catch (const std::exception &) {
-    if (_ifs.eof() && !_ifs.bad()) {
+  } catch (...) {
+    if (unsafe_eof() && !_ifs.bad()) {
       return !!_ifs;
     }
     throw;
   }
 }
 
-inline void FileStream::write(std::string_view buffer) {
-  return write(buffer.data(), buffer.size());
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline T FileStream<Mutex>::read() {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_read<T>();
 }
 
-inline void FileStream::write(const char *buffer, std::size_t count) {
-  _ofs.write(buffer, std::int64_t(count));
-  _file_size = std::max(static_cast<std::size_t>(_ofs.tellp()), _file_size);
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::read(T &buffer) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_read(buffer);
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::read(T &buffer) {
-  static_assert(sizeof(char) == 1);
-  return read(reinterpret_cast<char *>(&buffer), sizeof(T));
-}
-
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline T FileStream::read() {
-  T buffer{};
-  read(buffer);
-  return buffer;
-}
-
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::write(T buffer) {
-  static_assert(sizeof(char) == 1);
-  return write(reinterpret_cast<const char *>(&buffer), sizeof(T));
-}
-
-template <typename Tin, typename Tout,
-          typename std::enable_if<std::is_integral<Tin>::value>::type *>
-inline Tout FileStream::read_as_signed() {
-  auto tmp = read<Tin>();
+template <typename Mutex>
+template <typename Tin, typename Tout, typename std::enable_if_t<std::is_integral_v<Tin>> *>
+inline Tout FileStream<Mutex>::read_as_signed() {
   return conditional_static_cast<Tout>(read<Tin>());
 }
 
-template <typename Tin, typename Tout,
-          typename std::enable_if<std::is_integral<Tin>::value>::type *>
-inline Tout FileStream::read_as_unsigned() {
+template <typename Mutex>
+template <typename Tin, typename Tout, typename std::enable_if_t<std::is_integral_v<Tin>> *>
+inline Tout FileStream<Mutex>::read_as_unsigned() {
   return conditional_static_cast<Tout>(read<Tin>());
 }
 
-template <typename Tin, typename std::enable_if<std::is_arithmetic<Tin>::value>::type *>
-inline double FileStream::read_as_double() {
+template <typename Mutex>
+template <typename Tin, typename std::enable_if_t<std::is_arithmetic_v<Tin>> *>
+inline double FileStream<Mutex>::read_as_double() {
   return conditional_static_cast<double>(read<Tin>());
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::read(std::vector<T> &buffer) {
-  static_assert(sizeof(char) == 1);
-  return read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_read(T &buffer) {
+  unsafe_read(reinterpret_cast<char *>(&buffer), sizeof(T));
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::write(const std::vector<T> &buffer) {
-  static_assert(sizeof(char) == 1);
-  return write(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline T FileStream<Mutex>::unsafe_read() {
+  T buffer{};
+  unsafe_read(buffer);
+  return buffer;
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline std::vector<T> FileStream::read(std::size_t size) {
-  assert(size != 0);
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::read(std::vector<T> &buffer) {
+  read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::vector<T> FileStream<Mutex>::read_vector(std::size_t size) {
   std::vector<T> buffer(size);
   read(buffer);
   return buffer;
 }
 
-inline std::string FileStream::getline(char delim) {
-  std::string buffer{};
-  getline(buffer, delim);
-  return buffer;
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, std::vector<T> &buffer, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  unsafe_read(buffer);
+  const auto num_bytes = buffer.size() * sizeof(T);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(num_bytes));
 }
 
-inline std::streampos FileStream::new_posg(std::streamoff offset, std::ios::seekdir way) {
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_read(std::vector<T> &buffer) {
+  unsafe_read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::write(const char *buffer, std::size_t count) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_write(buffer, count);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, const char *buffer, std::size_t count, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellp();
+  unsafe_seekp(offset, way);
+  unsafe_write(buffer, count);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_write(const char *buffer, std::size_t count) {
+  _ofs.write(buffer, static_cast<std::streamsize>(count));
+  _file_size = std::max(static_cast<std::streamsize>(unsafe_tellp()), _file_size);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(const char *buffer,
+                                                                           std::size_t count) {
+  const auto lck = lock();
+  unsafe_seekp(0, std::ios::end);
+  const auto offset = unsafe_tellp();
+  unsafe_write(buffer, count);
+
+  return std::make_pair(offset, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::write(std::string_view buffer) {
+  return write(buffer.data(), buffer.size());
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, std::string_view buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, buffer.data(), buffer.size(), way);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(
+    std::string_view buffer) {
+  return append(buffer.data(), buffer.size());
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::write(T buffer) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_write(buffer);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_write(T buffer) {
+  return unsafe_write(reinterpret_cast<const char *>(&buffer), sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(T buffer) {
+  return append(reinterpret_cast<const char *>(&buffer), sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, T buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, reinterpret_cast<const char *>(&buffer), sizeof(T), way);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::write(const std::vector<T> &buffer) {
+  return write(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, const std::vector<T> &buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, reinterpret_cast<const char *>(buffer.data()),
+                        buffer.size() * sizeof(T), way);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(
+    const std::vector<T> &buffer) {
+  return append(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posg(std::streamoff offset, std::ios::seekdir way) {
   switch (way) {
     case std::ios::beg:
-      return static_cast<std::streampos>(offset);
+      return offset;
     case std::ios::cur:
-      return std::int64_t(tellg()) + offset;
+      return unsafe_tellg() + offset;
     case std::ios::end:
-      return std::int64_t(_file_size) + offset;
+      return static_cast<std::streampos>(_file_size) - offset;
     default:
       HICTK_UNREACHABLE_CODE;
   }
 }
 
-inline std::streampos FileStream::new_posp(std::streamoff offset, std::ios::seekdir way) {
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posg_checked(std::streamoff offset,
+                                                          std::ios::seekdir way) {
+  const auto new_pos = new_posg(offset, way);
+  if (new_pos < 0 || new_pos >= static_cast<std::streampos>(_file_size + 1)) {
+    throw std::runtime_error(get_underlying_os_error());
+  }
+  return new_pos;
+}
+
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posp(std::streamoff offset, std::ios::seekdir way) {
   switch (way) {
     case std::ios::beg:
-      return static_cast<std::streampos>(offset);
+      return offset;
     case std::ios::cur:
-      return std::int64_t(tellp()) + offset;
+      return unsafe_tellp() + offset;
     case std::ios::end:
-      return std::int64_t(_file_size) + offset;
+      return static_cast<std::streampos>(_file_size) - offset;
     default:
       HICTK_UNREACHABLE_CODE;
   }
 }
-
-inline void FileStream::update_file_size() {
-  const auto offset = _ifs.tellg();
-  _ifs.seekg(0, std::ios::end);
-  _file_size = std::max(static_cast<std::size_t>(_ifs.tellg()), _file_size);
-  _ifs.seekg(offset, std::ios::beg);
+template <typename Mutex>
+inline void FileStream<Mutex>::update_file_size() {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_update_file_size();
 }
 
-inline std::ifstream FileStream::open_file_read(const std::string &path,
-                                                std::ifstream::openmode mode) {
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_update_file_size() {
+  unsafe_flush();
+  const auto offset = unsafe_tellg();
+  unsafe_seekg(0, std::ios::end);
+  _file_size = std::max(unsafe_tellg(), _file_size);
+  unsafe_seekg(offset);
+}
+
+template <typename Mutex>
+inline std::ifstream FileStream<Mutex>::open_file_read(const std::string &path,
+                                                       std::ifstream::openmode mode) {
   std::ifstream fs;
   fs.exceptions(fs.exceptions() | std::ios::failbit | std::ios::badbit);
   fs.open(path, mode);
   return fs;
 }
 
-inline std::ofstream FileStream::open_file_write(const std::string &path,
-                                                 std::ofstream::openmode mode) {
+template <typename Mutex>
+inline std::ofstream FileStream<Mutex>::open_file_write(const std::string &path,
+                                                        std::ofstream::openmode mode) {
   std::ofstream fs;
   fs.exceptions(fs.exceptions() | std::ios::failbit | std::ios::badbit);
   fs.open(path, mode);
   return fs;
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::get_underlying_os_error() {
+  return get_underlying_os_error(errno);
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::get_underlying_os_error(int errno_) {
+  std::string buffer(256, '\0');
+  get_underlying_os_error(errno_, buffer);
+  return buffer;
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::get_underlying_os_error([[maybe_unused]] int errno_,
+                                                       std::string &buffer) {
+#ifdef _WIN32
+  if (const auto ec = GetLastError(); ec != 0) {
+    buffer = FormatSystemMessage(ec);
+    return;
+  }
+#endif
+
+  if (errno_ == 0) {
+    buffer = "Success";
+    return;
+  }
+#ifdef _GNU_SOURCE
+  buffer = strerror_r(errno_, buffer.data(), buffer.size());
+#else
+  const int status = strerror_r(errno_, buffer.data(), buffer.size());
+  switch (status) {
+    case 0: {
+      // strerror_r call was successful
+      if (const auto pos = buffer.find('\0'); pos != std::string::npos) {
+        if (pos == 0) {
+          // this should never happen
+          buffer.clear();
+        } else {
+          buffer.resize(pos - 1);
+        }
+      }
+      return;
+    }
+    case EINVAL: {
+      buffer = "strerror_r: unknown errno: " + std::to_string(errno_);
+      return;
+    }
+    case ERANGE: {
+      buffer.resize(buffer.size() * 2, '\0');
+      return get_underlying_os_error(errno_, buffer);
+    }
+    default: {
+      assert(status < 0);
+      // on old versions of glibc error is communicated through a new errno value
+      get_underlying_os_error(errno, buffer);
+      buffer = "strerror_r: " + buffer;
+    }
+  }
+#endif
+}
+
+template <typename Mutex>
+template <typename T, typename I1, typename I2>
+inline void FileStream<Mutex>::validate_read(I1 bytes_read, I2 count_expected,
+                                             std::string_view prefix) {
+  static_assert(std::is_arithmetic_v<T>);
+  static_assert(std::is_integral_v<I1> || is_specialization_v<I1, std::fpos>);
+  static_assert(std::is_integral_v<I2> || is_specialization_v<I1, std::fpos>);
+
+  if constexpr (std::is_signed_v<I1>) {
+    assert(bytes_read >= 0);
+  }
+  if constexpr (std::is_signed_v<I2>) {
+    assert(count_expected >= 0);
+  }
+
+  const auto bytes_expected = conditional_static_cast<std::size_t>(count_expected) * sizeof(T);
+  if (conditional_static_cast<std::size_t>(bytes_read) == bytes_expected) {
+    return;
+  }
+
+  assert(conditional_static_cast<std::size_t>(bytes_read) < bytes_expected);
+  throw std::runtime_error(std::string{prefix} + " failed: expected to read " +
+                           std::to_string(bytes_expected) + " bytes, but only read " +
+                           std::to_string(bytes_read));
 }
 
 }  // namespace hictk::filestream

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -66,6 +66,7 @@ inline FileStream<Mutex> FileStream<Mutex>::create(std::string path, std::shared
 template <typename Mutex>
 inline FileStream<Mutex>::FileStream(FileStream &&other) noexcept
     : _path(std::move(other._path)),
+      _mtx(std::move(other._mtx)),
       _ifs(std::move(other._ifs)),
       _ofs(std::move(other._ofs)),
       _file_size(other._file_size) {}
@@ -79,6 +80,7 @@ inline FileStream<Mutex> &FileStream<Mutex>::operator=(FileStream &&other) noexc
   }
 
   _path = std::move(other._path);
+  _mtx = std::move(other._mtx);
   _ifs = std::move(other._ifs);
   _ofs = std::move(other._ofs);
   _file_size = other._file_size;

--- a/src/libhictk/hic/include/hictk/hic/file_reader.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_reader.hpp
@@ -28,7 +28,7 @@ namespace hictk::hic::internal {
 
 class HiCFileReader {
   using Decompressor = UniquePtrWithDeleter<libdeflate_decompressor>;
-  std::shared_ptr<filestream::FileStream> _fs{};
+  std::shared_ptr<filestream::FileStream<>> _fs{};
   std::shared_ptr<const HiCHeader> _header{};
   std::string _strbuff{};
   Decompressor _decompressor{init_decompressor()};
@@ -66,10 +66,10 @@ class HiCFileReader {
       MatrixType matrix_type, MatrixUnit wanted_unit, std::uint32_t wanted_resolution);
   [[nodiscard]] std::vector<balancing::Method> list_avail_normalizations_v9();
 
-  [[nodiscard]] static MatrixType readMatrixType(filestream::FileStream &fs, std::string &buff);
-  [[nodiscard]] static balancing::Method readNormalizationMethod(filestream::FileStream &fs,
+  [[nodiscard]] static MatrixType readMatrixType(filestream::FileStream<> &fs, std::string &buff);
+  [[nodiscard]] static balancing::Method readNormalizationMethod(filestream::FileStream<> &fs,
                                                                  std::string &buff);
-  [[nodiscard]] static MatrixUnit readMatrixUnit(filestream::FileStream &fs, std::string &buff);
+  [[nodiscard]] static MatrixUnit readMatrixUnit(filestream::FileStream<> &fs, std::string &buff);
 
   [[nodiscard]] Index read_index(std::int64_t fileOffset, const Chromosome &chrom1,
                                  const Chromosome &chrom2, MatrixUnit wantedUnit,
@@ -79,10 +79,10 @@ class HiCFileReader {
   [[nodiscard]] static bool checkMagicString(std::string url) noexcept;
 
  private:
-  [[nodiscard]] static filestream::FileStream openStream(std::string url);
+  [[nodiscard]] static filestream::FileStream<> openStream(std::string url);
   // reads the header, storing the positions of the normalization vectors and returning the
   // masterIndexPosition pointer
-  [[nodiscard]] static HiCHeader readHeader(filestream::FileStream &fs);
+  [[nodiscard]] static HiCHeader readHeader(filestream::FileStream<> &fs);
 
   [[nodiscard]] std::vector<double> readExpectedVector(std::int64_t nValues);
   [[nodiscard]] std::vector<double> readNormalizationFactors(std::uint32_t wantedChrom);
@@ -100,7 +100,7 @@ class HiCFileReader {
 
   [[nodiscard]] std::int64_t readNValues();
   [[nodiscard]] bool checkMagicString();
-  [[nodiscard]] static bool checkMagicString(filestream::FileStream &fs);
+  [[nodiscard]] static bool checkMagicString(filestream::FileStream<> &fs);
   [[nodiscard]] std::int64_t masterOffset() const noexcept;
 
   [[nodiscard]] static auto init_decompressor() -> Decompressor;

--- a/src/libhictk/hic/include/hictk/hic/file_writer.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer.hpp
@@ -155,8 +155,7 @@ class HiCFileWriter {
       std::string_view assembly_ = "unknown", std::size_t n_threads = 1,
       std::size_t chunk_size = 10'000'000,
       const std::filesystem::path& tmpdir = hictk::internal::TmpDir::default_temp_directory_path(),
-      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false,
-      std::size_t buffer_size = 32'000'000);
+      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false);
 
   [[nodiscard]] std::string_view path() const noexcept;
   [[nodiscard]] const Reference& chromosomes() const noexcept;

--- a/src/libhictk/hic/include/hictk/hic/file_writer.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer.hpp
@@ -54,7 +54,7 @@ class HiCSectionOffsets {
 
   void extend(std::size_t s) noexcept;
   void extend(std::streamoff s) noexcept;
-  void set_size(std::size_t new_size) noexcept;
+  void set_size(std::size_t new_size);
 };
 
 struct BlockIndexKey {
@@ -261,7 +261,7 @@ class HiCFileWriter {
       phmap::flat_hash_map<std::uint64_t, std::string>& serialized_block_tank,
       std::mutex& serialized_block_tank_mtx, std::atomic<bool>& early_return,
       std::uint64_t stop_token) -> Stats;
-  void write_compressed_blocks_thr(
+  [[nodiscard]] std::streampos write_compressed_blocks_thr(
       const Chromosome& chrom1, const Chromosome& chrom2, std::uint32_t resolution,
       std::queue<std::uint64_t>& block_id_queue, std::mutex& block_id_queue_mtx,
       phmap::flat_hash_map<std::uint64_t, std::string>& serialized_block_tank,

--- a/src/libhictk/hic/include/hictk/hic/file_writer_data_structures.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer_data_structures.hpp
@@ -150,7 +150,10 @@ struct ExpectedValuesBlock {
   [[nodiscard]] bool operator<(const ExpectedValuesBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static ExpectedValuesBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static ExpectedValuesBlock deserialize(std::streampos offset,
+                                                       filestream::FileStream<>& fs);
+  [[nodiscard]] static ExpectedValuesBlock unsafe_deserialize(std::streampos offset,
+                                                              filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#expected-value-vectors
@@ -162,7 +165,10 @@ class ExpectedValues {
   [[nodiscard]] const phmap::btree_set<ExpectedValuesBlock>& expectedValues() const noexcept;
   void emplace(const ExpectedValuesBlock& evb, bool force_overwrite = false);
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static ExpectedValues deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static ExpectedValues deserialize(std::streampos offset,
+                                                  filestream::FileStream<>& fs);
+  [[nodiscard]] static ExpectedValues unsafe_deserialize(std::streampos offset,
+                                                         filestream::FileStream<>& fs);
 };
 
 struct NormalizedExpectedValuesBlock {
@@ -184,7 +190,10 @@ struct NormalizedExpectedValuesBlock {
   [[nodiscard]] bool operator<(const NormalizedExpectedValuesBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizedExpectedValuesBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizedExpectedValuesBlock deserialize(std::streampos offset,
+                                                                 filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizedExpectedValuesBlock unsafe_deserialize(
+      std::streampos offset, filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#normalized-expected-value-vectors
@@ -197,7 +206,10 @@ class NormalizedExpectedValues {
       const noexcept;
   void emplace(const NormalizedExpectedValuesBlock& evb, bool force_overwrite = false);
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizedExpectedValues deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizedExpectedValues deserialize(std::streampos offset,
+                                                            filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizedExpectedValues unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<>& fs);
 };
 
 struct NormalizationVectorIndexBlock {
@@ -217,7 +229,10 @@ struct NormalizationVectorIndexBlock {
   [[nodiscard]] bool operator<(const NormalizationVectorIndexBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizationVectorIndexBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizationVectorIndexBlock deserialize(std::streampos offset,
+                                                                 filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizationVectorIndexBlock unsafe_deserialize(
+      std::streampos offset, filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#normalization-vector-index
@@ -231,7 +246,10 @@ class NormalizationVectorIndex {
   void emplace_back(NormalizationVectorIndexBlock blk);
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizationVectorIndex deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizationVectorIndex deserialize(std::streampos offset,
+                                                            filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizationVectorIndex unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<>& fs);
 };
 
 }  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/header.hpp
+++ b/src/libhictk/hic/include/hictk/hic/header.hpp
@@ -34,7 +34,9 @@ struct HiCHeader {
   bool operator!=(const HiCHeader& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static HiCHeader deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static HiCHeader deserialize(std::streampos offset, filestream::FileStream<>& fs);
+  [[nodiscard]] static HiCHeader unsafe_deserialize(std::streampos offset,
+                                                    filestream::FileStream<>& fs);
 };
 
 }  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_data_structures_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_data_structures_impl.hpp
@@ -464,22 +464,31 @@ inline std::string ExpectedValuesBlock::serialize(BinaryBuffer &buffer, bool cle
   return buffer.get();
 }
 
-inline ExpectedValuesBlock ExpectedValuesBlock::deserialize(filestream::FileStream &fs) {
+inline ExpectedValuesBlock ExpectedValuesBlock::deserialize(std::streampos offset,
+                                                            filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline ExpectedValuesBlock ExpectedValuesBlock::unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   ExpectedValuesBlock evb{};
 
   try {
-    evb.unit = fs.getline('\0');
-    fs.read(evb.binSize);
-    const auto nValues = static_cast<std::size_t>(fs.read<std::int64_t>());
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(evb.unit, '\0');
+    fs.unsafe_read(evb.binSize);
+    const auto nValues = static_cast<std::size_t>(fs.unsafe_read<std::int64_t>());
     evb.value.resize(nValues);
-    fs.read(evb.value);
-    const auto nChrScaleFactors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_read(evb.value);
+    const auto nChrScaleFactors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     evb.chrIndex.resize(nChrScaleFactors);
     evb.chrScaleFactor.resize(nChrScaleFactors);
 
     for (std::size_t i = 0; i < nChrScaleFactors; ++i) {
-      evb.chrIndex.emplace_back(fs.read<std::int32_t>());
-      evb.chrScaleFactor.emplace_back(fs.read<float>());
+      evb.chrIndex.emplace_back(fs.unsafe_read<std::int32_t>());
+      evb.chrScaleFactor.emplace_back(fs.unsafe_read<float>());
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -535,13 +544,22 @@ inline std::string ExpectedValues::serialize(BinaryBuffer &buffer, bool clear) c
   return buffer.get();
 }
 
-inline ExpectedValues ExpectedValues::deserialize(filestream::FileStream &fs) {
+inline ExpectedValues ExpectedValues::deserialize(std::streampos offset,
+                                                  filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline ExpectedValues ExpectedValues::unsafe_deserialize(std::streampos offset,
+                                                         filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   ExpectedValues evs{};
 
   try {
-    const auto nExpectedValueVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nExpectedValueVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nExpectedValueVectors; ++i) {
-      evs.emplace(ExpectedValuesBlock::deserialize(fs), true);
+      evs.emplace(ExpectedValuesBlock::unsafe_deserialize(fs.unsafe_tellg(), fs), true);
     }
   } catch (const std::exception &e) {
     throw std::runtime_error("an error occurred while deserializing an ExpectedValues object: " +
@@ -615,25 +633,32 @@ inline std::string NormalizedExpectedValuesBlock::serialize(BinaryBuffer &buffer
 
   return buffer.get();
 }
-
 inline NormalizedExpectedValuesBlock NormalizedExpectedValuesBlock::deserialize(
-    filestream::FileStream &fs) {
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizedExpectedValuesBlock NormalizedExpectedValuesBlock::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizedExpectedValuesBlock nevb{};
 
   try {
-    nevb.type = fs.getline('\0');
-    nevb.unit = fs.getline('\0');
-    fs.read(nevb.binSize);
-    const auto nValues = static_cast<std::size_t>(fs.read<std::int64_t>());
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(nevb.type, '\0');
+    fs.unsafe_getline(nevb.unit, '\0');
+    fs.unsafe_read(nevb.binSize);
+    const auto nValues = static_cast<std::size_t>(fs.unsafe_read<std::int64_t>());
     nevb.value.resize(nValues);
-    fs.read(nevb.value);
-    const auto nChrScaleFactors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_read(nevb.value);
+    const auto nChrScaleFactors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     nevb.chrIndex.resize(nChrScaleFactors);
     nevb.chrScaleFactor.resize(nChrScaleFactors);
 
     for (std::size_t i = 0; i < nChrScaleFactors; ++i) {
-      nevb.chrIndex.emplace_back(fs.read<std::int32_t>());
-      nevb.chrScaleFactor.emplace_back(fs.read<float>());
+      nevb.chrIndex.emplace_back(fs.unsafe_read<std::int32_t>());
+      nevb.chrScaleFactor.emplace_back(fs.unsafe_read<float>());
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -686,13 +711,22 @@ inline std::string NormalizedExpectedValues::serialize(BinaryBuffer &buffer, boo
   return buffer.get();
 }
 
-inline NormalizedExpectedValues NormalizedExpectedValues::deserialize(filestream::FileStream &fs) {
+inline NormalizedExpectedValues NormalizedExpectedValues::deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizedExpectedValues NormalizedExpectedValues::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizedExpectedValues nevs{};
 
   try {
-    const auto nNormExpectedValueVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nNormExpectedValueVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nNormExpectedValueVectors; ++i) {
-      nevs.emplace(NormalizedExpectedValuesBlock::deserialize(fs), true);
+      nevs.emplace(NormalizedExpectedValuesBlock::unsafe_deserialize(fs.unsafe_tellg(), fs), true);
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -750,16 +784,24 @@ inline std::string NormalizationVectorIndexBlock::serialize(BinaryBuffer &buffer
 }
 
 inline NormalizationVectorIndexBlock NormalizationVectorIndexBlock::deserialize(
-    filestream::FileStream &fs) {
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizationVectorIndexBlock NormalizationVectorIndexBlock::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizationVectorIndexBlock nvib{};
 
   try {
-    nvib.type = fs.getline('\0');
-    nvib.chrIdx = fs.read<std::int32_t>();
-    nvib.unit = fs.getline('\0');
-    nvib.binSize = fs.read<std::int32_t>();
-    nvib.position = fs.read<std::int64_t>();
-    nvib.nBytes = fs.read<std::int64_t>();
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(nvib.type, '\0');
+    nvib.chrIdx = fs.unsafe_read<std::int32_t>();
+    fs.unsafe_getline(nvib.unit, '\0');
+    nvib.binSize = fs.unsafe_read<std::int32_t>();
+    nvib.position = fs.unsafe_read<std::int64_t>();
+    nvib.nBytes = fs.unsafe_read<std::int64_t>();
   } catch (const std::exception &e) {
     throw std::runtime_error(
         "an error occurred while deserializing a NormalizationVectorIndexBlock object: " +
@@ -802,13 +844,22 @@ inline std::string NormalizationVectorIndex::serialize(BinaryBuffer &buffer, boo
   return buffer.get();
 }
 
-inline NormalizationVectorIndex NormalizationVectorIndex::deserialize(filestream::FileStream &fs) {
+inline NormalizationVectorIndex NormalizationVectorIndex::deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizationVectorIndex NormalizationVectorIndex::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizationVectorIndex nvi{};
 
   try {
-    const auto nNormVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nNormVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nNormVectors; ++i) {
-      nvi.emplace_back(NormalizationVectorIndexBlock::deserialize(fs));
+      nvi.emplace_back(NormalizationVectorIndexBlock::unsafe_deserialize(fs.unsafe_tellg(), fs));
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
@@ -1246,7 +1246,6 @@ inline auto HiCFileWriter::write_interaction_block(std::streampos offset, std::u
                                                    const MatrixInteractionBlock<float> &blk)
     -> HiCSectionOffsets {
   assert(offset >= 0);
-  const auto offset = _fs.tellp();
   std::ignore = blk.serialize(_bbuffer, *_compressor, _compression_buffer);
   SPDLOG_DEBUG(FMT_STRING("writing block #{} for {}:{}:{} at {}:{}"), block_id, chrom1.name(),
                chrom2.name(), resolution, static_cast<std::int64_t>(offset),

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
@@ -1402,7 +1402,7 @@ inline void HiCFileWriter::read_offsets() {
     _norm_vector_index_section = {norm_vector_index_start,
                                   norm_vector_index_end - norm_vector_index_start};
 
-    _fs.seekg(0, std::ios::end);
+    _fs.unsafe_seekg(0, std::ios::end);
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while reading section offsets from file \"{}\": {}"), path(),

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
@@ -448,34 +448,13 @@ inline void HiCFileWriter::write_all_matrix(std::uint32_t target_num_bins) {
 inline auto HiCFileWriter::write_pixels(const Chromosome &chrom1, const Chromosome &chrom2)
     -> HiCSectionOffsets {
   try {
-    SPDLOG_INFO(FMT_STRING("about to write pixels for {}:{}: tellg={}; tellp={}; size={};"),
-                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(_fs.tellg()),
-                static_cast<std::int64_t>(_data_block_section.end()),
-                conditional_static_cast<std::int64_t>(_fs.size()));
     write_pixels(chrom1, chrom2, resolutions().front());
     add_body_metadata(resolutions().front(), chrom1, chrom2);
-    SPDLOG_INFO(FMT_STRING("about to write body metadata for {}:{}: tellg={}; tellp={}; size={};"),
-                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(_fs.tellg()),
-                static_cast<std::int64_t>(_fs.tellp()),
-                conditional_static_cast<std::int64_t>(_fs.size()));
     write_body_metadata();
     add_footer(chrom1, chrom2);
-    SPDLOG_INFO(FMT_STRING("about to write footers for {}:{}: tellg={}; tellp={}; size={};"),
-                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(_fs.tellg()),
-                static_cast<std::int64_t>(_fs.tellp()),
-                conditional_static_cast<std::int64_t>(_fs.size()));
     write_footers();
 
-    SPDLOG_INFO(FMT_STRING("about to finalize pixels for {}:{}: tellg={}; tellp={}; size={};"),
-                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(_fs.tellg()),
-                static_cast<std::int64_t>(_fs.tellp()),
-                conditional_static_cast<std::int64_t>(_fs.size()));
     finalize();
-
-    SPDLOG_INFO(FMT_STRING("DONE writing pixels for {}:{}: tellg={}; tellp={}; size={};"),
-                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(_fs.tellg()),
-                static_cast<std::int64_t>(_fs.tellp()),
-                conditional_static_cast<std::int64_t>(_fs.size()));
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING(

--- a/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
@@ -78,9 +78,17 @@ inline std::string HiCHeader::serialize(BinaryBuffer &buffer, bool clear) const 
   return buffer.get();
 }
 
-inline HiCHeader HiCHeader::deserialize(filestream::FileStream &fs) {
-  fs.seekg(0, std::ios::beg);
-  const auto magic_string_found = fs.getline('\0') == "HIC";
+inline HiCHeader HiCHeader::deserialize(std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline HiCHeader HiCHeader::unsafe_deserialize(std::streampos offset,
+                                               filestream::FileStream<> &fs) {
+  fs.unsafe_seekg(offset);
+  std::string strbuff;
+  fs.unsafe_getline(strbuff, '\0');
+  const auto magic_string_found = strbuff == "HIC";
   if (!magic_string_found) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("Hi-C magic string is missing. {} does not appear to be a hic file"),
@@ -89,48 +97,51 @@ inline HiCHeader HiCHeader::deserialize(filestream::FileStream &fs) {
 
   HiCHeader header{fs.path()};
 
-  fs.read(header.version);
+  fs.unsafe_read(header.version);
   if (header.version < 6) {
     throw std::runtime_error(fmt::format(
         FMT_STRING(".hic version 5 and older are no longer supported. Found version {}"),
         header.version));
   }
-  fs.read(header.footerPosition);
-  if (header.footerPosition < 0 || header.footerPosition >= static_cast<std::int64_t>(fs.size())) {
+  fs.unsafe_read(header.footerPosition);
+  if (header.footerPosition < 0 ||
+      header.footerPosition >= static_cast<std::int64_t>(fs.unsafe_size())) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("file appears to be corrupted: expected footerPosition to be "
                                "between 0 and {}, found {}"),
-                    fs.size(), header.footerPosition));
+                    fs.unsafe_size(), header.footerPosition));
   }
 
-  fs.getline(header.genomeID, '\0');
+  fs.unsafe_getline(header.genomeID, '\0');
   if (header.genomeID.empty()) {
     header.genomeID = "unknown";
   }
 
   if (header.version > 8) {
-    fs.read(header.normVectorIndexPosition);
-    fs.read(header.normVectorIndexLength);
+    fs.unsafe_read(header.normVectorIndexPosition);
+    fs.unsafe_read(header.normVectorIndexLength);
   }
 
-  const auto nAttributes = fs.read<std::int32_t>();
+  const auto nAttributes = fs.unsafe_read<std::int32_t>();
 
   // reading attribute-value dictionary
+  std::string key;
+  std::string value;
   for (std::int32_t i = 0; i < nAttributes; i++) {
-    auto key = fs.getline('\0');    // key
-    auto value = fs.getline('\0');  // value
-    header.attributes.emplace(std::move(key), std::move(value));
+    fs.unsafe_getline(key, '\0');
+    fs.unsafe_getline(value, '\0');
+    header.attributes.emplace(key, value);
   }
 
   // Read chromosomes
-  auto numChromosomes = static_cast<std::uint32_t>(fs.read<std::int32_t>());
+  auto numChromosomes = static_cast<std::uint32_t>(fs.unsafe_read<std::int32_t>());
   std::vector<std::string> chrom_names(numChromosomes);
   std::vector<std::uint32_t> chrom_sizes(numChromosomes);
   for (std::size_t i = 0; i < chrom_names.size(); ++i) {
-    fs.getline(chrom_names[i], '\0');
+    fs.unsafe_getline(chrom_names[i], '\0');
     chrom_sizes[i] = static_cast<std::uint32_t>(
-        header.version > 8 ? fs.read<std::int64_t>()
-                           : static_cast<std::int64_t>(fs.read<std::int32_t>()));
+        header.version > 8 ? fs.unsafe_read<std::int64_t>()
+                           : static_cast<std::int64_t>(fs.unsafe_read<std::int32_t>()));
   }
 
   if (chrom_names.empty()) {
@@ -140,7 +151,7 @@ inline HiCHeader HiCHeader::deserialize(filestream::FileStream &fs) {
   header.chromosomes = Reference(chrom_names.begin(), chrom_names.end(), chrom_sizes.begin());
 
   // Read resolutions
-  const auto numResolutions = static_cast<std::size_t>(fs.read<std::int32_t>());
+  const auto numResolutions = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
   if (numResolutions == 0) {
     throw std::runtime_error("unable to read the list of available resolutions");
   }
@@ -148,9 +159,11 @@ inline HiCHeader HiCHeader::deserialize(filestream::FileStream &fs) {
   // sometimes .hic files have duplicate resolutions for some obscure reason...
   phmap::btree_set<std::uint32_t> resolutions{};
   for (std::size_t i = 0; i < numResolutions; ++i) {
-    const auto res = fs.read_as_unsigned<std::int32_t>();
+    const auto res = static_cast<std::uint32_t>(fs.unsafe_read<std::int32_t>());
     resolutions.emplace(res);
   }
+
+  header.resolutions.reserve(resolutions.size());
   std::copy(resolutions.begin(), resolutions.end(), std::back_inserter(header.resolutions));
 
   return header;

--- a/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
@@ -44,7 +44,7 @@ inline std::string HiCHeader::serialize(BinaryBuffer &buffer, bool clear) const 
   buffer.write("HIC\0", 4);
   buffer.write(version);
   buffer.write(footerPosition);
-  buffer.write(genomeID.c_str(), genomeID.size() + 1);
+  buffer.write(genomeID, true);
   buffer.write(normVectorIndexPosition);
   buffer.write(normVectorIndexLength);
 
@@ -52,8 +52,8 @@ inline std::string HiCHeader::serialize(BinaryBuffer &buffer, bool clear) const 
   const auto nAttributes = static_cast<std::int32_t>(attributes.size());
   buffer.write(nAttributes);
   for (const auto &[k, v] : attributes) {
-    buffer.write(k.c_str(), k.size() + 1);
-    buffer.write(v.c_str(), v.size() + 1);
+    buffer.write(k, true);
+    buffer.write(v, true);
   }
 
   // Write chromosomes
@@ -62,7 +62,7 @@ inline std::string HiCHeader::serialize(BinaryBuffer &buffer, bool clear) const 
 
   for (const Chromosome &c : chromosomes) {
     const auto name = std::string{c.name()};
-    buffer.write(name.c_str(), name.size() + 1);
+    buffer.write(name, true);
     buffer.write<std::int64_t>(c.size());
   }
 

--- a/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/header_impl.hpp
@@ -105,7 +105,7 @@ inline HiCHeader HiCHeader::unsafe_deserialize(std::streampos offset,
   }
   fs.unsafe_read(header.footerPosition);
   if (header.footerPosition < 0 ||
-      header.footerPosition >= static_cast<std::int64_t>(fs.unsafe_size())) {
+      header.footerPosition >= conditional_static_cast<std::int64_t>(fs.unsafe_size())) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("file appears to be corrupted: expected footerPosition to be "
                                "between 0 and {}, found {}"),

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -159,7 +159,7 @@ inline HiCInteractionToBlockMapper::HiCInteractionToBlockMapper(
 
 inline HiCInteractionToBlockMapper::~HiCInteractionToBlockMapper() noexcept {
   try {
-    _fs = filestream::FileStream();
+    _fs = filestream::FileStream<>();
     std::filesystem::remove(_path);
   } catch (...) {
   }

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -159,7 +159,7 @@ inline HiCInteractionToBlockMapper::HiCInteractionToBlockMapper(
 
 inline HiCInteractionToBlockMapper::~HiCInteractionToBlockMapper() noexcept {
   try {
-    _fs = filestream::FileStream<>();
+    _fs.close();
     std::filesystem::remove(_path);
   } catch (...) {
   }

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -127,6 +127,16 @@ inline bool HiCInteractionToBlockMapper::BlockID::operator<(const BlockID &other
   return bid < other.bid;
 }
 
+inline bool HiCInteractionToBlockMapper::BlockID::operator>(const BlockID &other) const noexcept {
+  if (chrom1_id != other.chrom1_id) {
+    return chrom1_id > other.chrom1_id;
+  }
+  if (chrom2_id != other.chrom2_id) {
+    return chrom2_id > other.chrom2_id;
+  }
+  return bid > other.bid;
+}
+
 inline bool HiCInteractionToBlockMapper::BlockID::operator==(const BlockID &other) const noexcept {
   return chrom1_id == other.chrom1_id && chrom2_id == other.chrom2_id && bid == other.bid;
 }
@@ -293,7 +303,7 @@ inline auto HiCInteractionToBlockMapper::block_index() const noexcept -> const B
 }
 
 inline auto HiCInteractionToBlockMapper::chromosome_index() const noexcept
-    -> const ChromosomeIndexMap & {
+    -> const MatrixIndexMap & {
   return _chromosome_index;
 }
 

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -471,7 +471,7 @@ inline std::vector<Pixel<float>> HiCInteractionToBlockMapper::fetch_pixels(
 
 inline void HiCInteractionToBlockMapper::write_blocks() {
   if (!std::filesystem::exists(_path)) {
-    _fs = filestream::FileStream::create(_path.string());
+    _fs = filestream::FileStream<>::create(_path.string(), std::make_shared<std::mutex>());
   }
   SPDLOG_DEBUG(FMT_STRING("writing {} pixels to file {}..."), _pending_pixels, _path);
   for (auto &[bid, blk] : _blocks) {

--- a/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "hictk/common.hpp"
+
+namespace hictk::hic::internal {
+template <typename BlockID>
+inline SerializedBlockPQueue<BlockID>::Record::operator bool() const noexcept {
+  return status == Status::SUCCESS;
+}
+
+template <typename BlockID>
+template <typename It>
+inline SerializedBlockPQueue<BlockID>::SerializedBlockPQueue(It first_bid, It last_bid,
+                                                             std::size_t producers_,
+                                                             std::size_t capacity_)
+    : _block_ids(first_bid, last_bid), _producers(producers_) {
+  if (_block_ids.empty()) {
+    _capacity = 0;
+    return;
+  }
+
+  _capacity = std::max(capacity_ == 0 ? 3 * _producers : capacity_, std::size_t{2});
+  std::sort(_block_ids.begin(), _block_ids.end(), std::greater{});
+
+  SPDLOG_DEBUG(FMT_STRING("initialized a BlockPQueue with capacity blocks with bids {}-{}"),
+               _capacity, _block_ids.back(), _block_ids.front());
+}
+
+template <typename BlockID>
+inline std::size_t SerializedBlockPQueue<BlockID>::size() const {
+  [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+  return _buff.size();
+}
+
+template <typename BlockID>
+inline std::size_t SerializedBlockPQueue<BlockID>::capacity() const noexcept {
+  return _capacity;
+}
+
+template <typename BlockID>
+inline bool SerializedBlockPQueue<BlockID>::try_enqueue(const BlockID& block_id,
+                                                        const std::string& serialized_block,
+                                                        std::chrono::milliseconds timeout) {
+  assert(!_block_ids.empty());
+  const auto expiration = std::chrono::steady_clock::now() + timeout;
+  while (HICTK_LIKELY(std::chrono::steady_clock::now() < expiration)) {
+    {
+      [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+      if (HICTK_LIKELY(_buff.size() < _capacity - 1) || block_id == _block_ids.back()) {
+        _buff.emplace(block_id, serialized_block);
+        SPDLOG_DEBUG(
+            FMT_STRING("SerializedBlockPQueue::try_enqueue(): successfully enqueued block {}"),
+            block_id);
+        return true;
+      }
+    }
+    SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::try_enqueue(): failed to enqueue block {} "
+                            "(queue is full). Sleeping "
+                            "before trying one more time..."),
+                 block_id);
+    std::this_thread::sleep_for(timeout / 25);
+  }
+
+  SPDLOG_DEBUG(
+      FMT_STRING("SerializedBlockPQueue::try_enqueue(): failed to enqueue block {}: timed out!"),
+      block_id);
+  return false;
+}
+
+template <typename BlockID>
+inline auto SerializedBlockPQueue<BlockID>::dequeue_timed(std::chrono::milliseconds timeout)
+    -> Record {
+  const auto expiration = std::chrono::steady_clock::now() + timeout;
+  while (HICTK_LIKELY(std::chrono::steady_clock::now() < expiration)) {
+    {
+      [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+      auto result = dequeue_unsafe();
+      if (result.status != Record::Status::NOT_AVAILABLE) {
+        return result;
+      }
+    }
+    SPDLOG_DEBUG(
+        FMT_STRING("SerializedBlockPQueue::dequeue_timed(): queue is empty. Sleeping before trying "
+                   "one more time..."));
+    std::this_thread::sleep_for(timeout / 25);
+  }
+
+  SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_timed(): operation timed out"));
+  return {{}, "", Record::Status::TIMEOUT};
+}
+
+template <typename BlockID>
+inline void SerializedBlockPQueue<BlockID>::dequeue(std::vector<Record>& buffer) {
+  buffer.clear();
+  [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+  while (true) {
+    auto record = dequeue_unsafe();
+    if (!record) {
+      SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue(): dequeued {} blocks"),
+                   buffer.size());
+      return;
+    }
+    buffer.emplace_back(std::move(record));
+  }
+}
+
+template <typename BlockID>
+inline auto SerializedBlockPQueue<BlockID>::dequeue_unsafe() noexcept -> Record {
+  if (HICTK_UNLIKELY(_block_ids.empty())) {
+    SPDLOG_DEBUG(
+        FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): caught attempt to fetch block from a "
+                   "closed queue"));
+    return {{}, "", Record::Status::QUEUE_IS_CLOSED};
+  }
+
+  if (_buff.empty()) {
+    SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): queue is empty!"));
+  }
+
+  assert(!_block_ids.empty());
+  auto& [bid, value] = *_buff.begin();
+  if (bid == _block_ids.back()) {
+    assert(!value.empty());
+    SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): returning block {}..."), bid);
+    Record record{bid, std::move(value), Record::Status::SUCCESS};
+    _buff.erase(_buff.begin());
+    _block_ids.pop_back();
+    return record;
+  }
+
+  SPDLOG_DEBUG(
+      FMT_STRING("SerializedBlockPQueue::dequeue_undafe(): block {} has not yet been enqueued!"),
+      bid);
+  return {{}, "", Record::Status::NOT_AVAILABLE};
+}
+
+}  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
+++ b/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
@@ -13,6 +13,7 @@
 #else
 #include <readerwriterqueue/readerwriterqueue.h>
 #endif
+#include <fmt/format.h>
 #include <zstd.h>
 
 #include <BS_thread_pool.hpp>
@@ -69,6 +70,7 @@ class HiCInteractionToBlockMapper {
     std::uint64_t bid;
 
     [[nodiscard]] bool operator<(const BlockID& other) const noexcept;
+    [[nodiscard]] bool operator>(const BlockID& other) const noexcept;
     [[nodiscard]] bool operator==(const BlockID& other) const noexcept;
   };
 
@@ -77,16 +79,18 @@ class HiCInteractionToBlockMapper {
     std::uint32_t size;
   };
 
+  using BlockIndexMap = phmap::btree_map<BlockID, std::vector<BlockIndex>>;
+
  private:
   std::filesystem::path _path{};
   filestream::FileStream<> _fs{};
   std::shared_ptr<const BinTable> _bin_table{};
 
-  using BlockIndexMap = phmap::btree_map<BlockID, std::vector<BlockIndex>>;
-  using ChromosomeIndexMap =
+  using MatrixIndexMap =
       phmap::flat_hash_map<std::pair<Chromosome, Chromosome>, phmap::btree_set<BlockID>>;
+
   BlockIndexMap _block_index{};
-  ChromosomeIndexMap _chromosome_index{};
+  MatrixIndexMap _chromosome_index{};
 
   phmap::btree_map<BlockID, MatrixInteractionBlockFlat<float>> _blocks{};
   phmap::flat_hash_map<std::pair<Chromosome, Chromosome>, float> _pixel_sums{};
@@ -139,7 +143,7 @@ class HiCInteractionToBlockMapper {
                      std::uint32_t update_frequency = 10'000'000);
 
   [[nodiscard]] auto block_index() const noexcept -> const BlockIndexMap&;
-  [[nodiscard]] auto chromosome_index() const noexcept -> const ChromosomeIndexMap&;
+  [[nodiscard]] auto chromosome_index() const noexcept -> const MatrixIndexMap&;
   [[nodiscard]] auto merge_blocks(const BlockID& bid) -> MatrixInteractionBlock<float>;
   [[nodiscard]] auto merge_blocks(const BlockID& bid, BinaryBuffer& bbuffer, ZSTD_DCtx_s& zstd_dctx,
                                   std::string& compression_buffer, std::mutex& mtx)
@@ -220,5 +224,25 @@ struct std::hash<hictk::hic::internal::HiCInteractionToBlockMapper::BlockID> {
     return hictk::internal::hash_combine(0, bid.chrom1_id, bid.chrom2_id, bid.bid);
   }
 };
+
+namespace fmt {
+template <>
+struct formatter<hictk::hic::internal::HiCInteractionToBlockMapper::BlockID> {
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+    if (ctx.begin() != ctx.end() && *ctx.begin() != '}') {
+      throw fmt::format_error("invalid format");
+    }
+
+    return ctx.end();
+  }
+
+  inline format_context::iterator format(
+      const hictk::hic::internal::HiCInteractionToBlockMapper::BlockID& bid,
+      format_context& ctx) const {
+    return fmt::format_to(ctx.out(), FMT_STRING("{}"), bid.bid);
+  }
+};
+
+}  // namespace fmt
 
 #include "./impl/interaction_to_block_mapper_impl.hpp"  // NOLINT

--- a/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
+++ b/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
@@ -79,7 +79,7 @@ class HiCInteractionToBlockMapper {
 
  private:
   std::filesystem::path _path{};
-  filestream::FileStream _fs{};
+  filestream::FileStream<> _fs{};
   std::shared_ptr<const BinTable> _bin_table{};
 
   using BlockIndexMap = phmap::btree_map<BlockID, std::vector<BlockIndex>>;

--- a/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
+++ b/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <parallel_hashmap/btree.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace hictk::hic::internal {
+
+template <typename BlockID>
+class SerializedBlockPQueue {
+  std::vector<BlockID> _block_ids{};
+  phmap::btree_map<BlockID, std::string> _buff{};
+  mutable std::mutex _mtx{};
+  std::size_t _capacity{256};
+  std::size_t _producers{1};
+
+ public:
+  struct Record {
+    enum class Status : std::uint_fast8_t { SUCCESS, TIMEOUT, NOT_AVAILABLE, QUEUE_IS_CLOSED };
+
+    BlockID bid{};
+    std::string serialized_block{};
+    Status status{Status::SUCCESS};
+
+    [[nodiscard]] explicit operator bool() const noexcept;
+  };
+
+  SerializedBlockPQueue() = default;
+  template <typename It>
+  SerializedBlockPQueue(It first_bid, It last_bid, std::size_t producers,
+                        std::size_t capacity_ = 0);
+
+  [[nodiscard]] std::size_t size() const;
+  [[nodiscard]] std::size_t capacity() const noexcept;
+
+  [[nodiscard]] bool try_enqueue(const BlockID& block_id, const std::string& serialized_block,
+                                 std::chrono::milliseconds timeout = std::chrono::seconds(1));
+  [[nodiscard]] auto dequeue_timed(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(50)) -> Record;
+  void dequeue(std::vector<Record>& buffer);
+
+ private:
+  [[nodiscard]] auto dequeue_unsafe() noexcept -> Record;
+};
+
+}  // namespace hictk::hic::internal
+
+#include "./impl/serialized_block_pqueue_impl.hpp"

--- a/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
+++ b/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
@@ -50,6 +50,7 @@ class SerializedBlockPQueue {
 
  private:
   [[nodiscard]] auto dequeue_unsafe() noexcept -> Record;
+  void dequeue_unsafe(std::vector<Record>& buffer);
 };
 
 }  // namespace hictk::hic::internal

--- a/test/units/balancing/matrix_test.cpp
+++ b/test/units/balancing/matrix_test.cpp
@@ -532,7 +532,7 @@ const std::vector<ThinPixel<std::int32_t>> pixels{
     std::string buff{};
 
     SECTION("empty matrix") {
-      auto f = filestream::FileStream::create(tmpfile.string());
+      auto f = filestream::FileStream<>::create(tmpfile.string(), nullptr);
 
       SparseMatrix m1{};
       SparseMatrix m2{};
@@ -554,7 +554,7 @@ const std::vector<ThinPixel<std::int32_t>> pixels{
       m1.finalize();
 
       std::filesystem::remove(tmpfile);  // NOLINT
-      auto f = filestream::FileStream::create(tmpfile.string());
+      auto f = filestream::FileStream<>::create(tmpfile.string(), nullptr);
 
       SparseMatrix m2{};
       m1.serialize(f, buff, *zstd_cctx);

--- a/test/units/filestream/filestream_test.cpp
+++ b/test/units/filestream/filestream_test.cpp
@@ -224,7 +224,7 @@ TEST_CASE("FileStream read", "[filestream][short]") {
       std::size_t failures = 0;
 
       threads_started++;
-      while (threads_started != 2);
+      while (threads_started != 2);  // NOLINT
 
       try {
         const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -355,7 +355,7 @@ TEST_CASE("FileStream getline", "[filestream][short]") {
       std::size_t failures = 0;
 
       threads_started++;
-      while (threads_started != 2);
+      while (threads_started != 2);  // NOLINT
 
       try {
         const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -524,7 +524,7 @@ TEST_CASE("FileStream write", "[filestream][short]") {
       std::size_t failures = 0;
 
       threads_started++;
-      while (threads_started != 2);
+      while (threads_started != 2);  // NOLINT
 
       try {
         const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);

--- a/test/units/filestream/filestream_test.cpp
+++ b/test/units/filestream/filestream_test.cpp
@@ -606,4 +606,27 @@ TEST_CASE("FileStream write binary", "[filestream][short]") {
   }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("FileStream resize", "[filestream][short]") {
+  const auto tmpfile = testdir() / "filestream_write.bin";
+  std::filesystem::remove(tmpfile);  // NOLINT
+  auto s = FileStream<>::create(tmpfile.string(), nullptr);
+
+  const std::string_view msg{"this is a relatively long string"};
+
+  s.write(msg);
+  CHECK(s.size() == conditional_static_cast<std::streamsize>(msg.size()));
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == s.size());
+
+  s.resize(5);
+  CHECK(s.size() == std::streamsize{5});
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == 5);
+
+  s.resize(100);
+  CHECK(s.size() == std::streamsize{100});
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == 5);
+}
 }  // namespace hictk::filestream::test

--- a/test/units/filestream/filestream_test.cpp
+++ b/test/units/filestream/filestream_test.cpp
@@ -231,6 +231,7 @@ TEST_CASE("FileStream read", "[filestream][short]") {
         for (; std::chrono::steady_clock::now() < timepoint; ++tests) {
           buffer_.clear();
           const auto new_offset = s.seek_and_read(offset, buffer_, expected_.size()).second;
+          // NOLINTNEXTLINE(readability-implicit-bool-conversion)
           failures += new_offset != offset + std::streamoff(expected_.size());
 
           [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);
@@ -354,6 +355,8 @@ TEST_CASE("FileStream getline", "[filestream][short]") {
       std::size_t tests = 0;
       std::size_t failures = 0;
 
+      const auto offset_after_read_expected = offset + std::streamoff(expected_.size() + 1);
+
       threads_started++;
       while (threads_started != 2);  // NOLINT
 
@@ -365,12 +368,12 @@ TEST_CASE("FileStream getline", "[filestream][short]") {
           const auto delimiter_found = std::get<0>(status);
           const auto offset_after_read = std::get<2>(status);
 
-          failures +=
-              offset_after_read != offset + std::streamoff(expected_.size() + delimiter_found) ||
-              expected_ != buffer_;
+          failures += static_cast<std::size_t>(offset_after_read != offset_after_read_expected ||
+                                               expected_ != buffer_);
 
           [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);
-          CHECK(offset_after_read == offset + std::streamoff(expected_.size() + delimiter_found));
+          CHECK(delimiter_found);
+          CHECK(offset_after_read == offset_after_read_expected);
           CHECK(expected_ == buffer_);
         }
 
@@ -530,6 +533,7 @@ TEST_CASE("FileStream write", "[filestream][short]") {
         const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
         for (; std::chrono::steady_clock::now() < timepoint; ++tests) {
           const auto new_offset = s.seek_and_write(offset, message).second;
+          // NOLINTNEXTLINE(readability-implicit-bool-conversion)
           failures += offset + static_cast<std::streamoff>(message.size()) != new_offset;
 
           [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);

--- a/test/units/filestream/filestream_test.cpp
+++ b/test/units/filestream/filestream_test.cpp
@@ -506,6 +506,7 @@ TEST_CASE("FileStream write", "[filestream][short]") {
     CHECK(s.size() == buffer.size() + offset);
   }
   SECTION("multi-threaded") {
+    s.close();
     std::filesystem::remove(tmpfile);  // NOLINT
     s = FileStream<>::create(tmpfile.string(), std::make_shared<std::mutex>());
 

--- a/test/units/hic/file_writer_test.cpp
+++ b/test/units/hic/file_writer_test.cpp
@@ -130,7 +130,7 @@ TEST_CASE("HiC: SerializedBlockPQueue", "[hic][v9][short]") {
     std::mt19937_64 rand_eng_(rd_());
 
     ++threads_started;
-    while (threads_started != num_threads);
+    while (threads_started != num_threads);  // NOLINT
 
     while (true) {
       const auto idx = i++;
@@ -144,7 +144,7 @@ TEST_CASE("HiC: SerializedBlockPQueue", "[hic][v9][short]") {
       std::this_thread::sleep_for(sleep_time);
 
       const auto& record = records[idx];
-      while (!queue.try_enqueue(record.bid, record.serialized_block));
+      while (!queue.try_enqueue(record.bid, record.serialized_block));  // NOLINT
     }
   };
 


### PR DESCRIPTION
This PR introduces two main changes:
- updating the `FileStream` class to expose several member functions to perform atomic reads and writes to binary files
- updating HiCFileWriter to take advantage of the new `FileStream` functionality
- optimize serialization of .hic files (the optimizations are especially noticeable when writing .hic files using a low number of threads)
