### PR TITLE
Refactor FileStream class

### DIFF
--- a/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/sparse_matrix.hpp
@@ -128,9 +128,9 @@ class SparseMatrix {
   void push_back(std::uint64_t bin1_id, std::uint64_t bin2_id, double count,
                  std::size_t bin_offset = 0);
 
-  void serialize(filestream::FileStream& fs, std::string& tmpbuff, ZSTD_CCtx& ctx,
+  void serialize(filestream::FileStream<>& fs, std::string& tmpbuff, ZSTD_CCtx& ctx,
                  int compression_lvl = 3) const;
-  void deserialize(filestream::FileStream& fs, std::string& tmpbuff, ZSTD_DCtx& ctx);
+  void deserialize(filestream::FileStream<>& fs, std::string& tmpbuff, ZSTD_DCtx& ctx);
 
   void marginalize(VectorOfAtomicDecimals& marg, bool init_buffer = true) const;
   void marginalize_nnz(VectorOfAtomicDecimals& marg, bool init_buffer = true) const;
@@ -180,9 +180,9 @@ class FileBackedSparseMatrix {
   mutable SparseMatrix _matrix{};
   mutable std::string _buff{};
   std::filesystem::path _path{};
-  mutable filestream::FileStream _fs{};
+  mutable filestream::FileStream<> _fs{};
 
-  std::vector<std::size_t> _index{};
+  std::vector<std::streampos> _index{};
   std::size_t _size{};
   std::size_t _chunk_size{};
   int _compression_lvl{};

--- a/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/binary_buffer.hpp
@@ -7,12 +7,17 @@
 #include <cstddef>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
 namespace hictk {
 
 class BinaryBuffer {
+  static_assert(sizeof(char) == 1);
+  static_assert(sizeof(float) == 4);
+  static_assert(sizeof(double) == 8);
+
   std::string _buffer{};
   std::size_t _i{};
 
@@ -20,20 +25,21 @@ class BinaryBuffer {
   BinaryBuffer() = default;
 
   // NOLINTNEXTLINE
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   T read();
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void read(T& buff);
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void read(std::vector<T>& buff);
   void read(std::string& buff, std::size_t n);
   void read(char* buff, std::size_t n);
   std::string getline(char delim = '\n');
-  // NOLINTNEXTLINE
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+
+  void write(const char* data, std::size_t count, bool add_nullterm = false);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void write(T data);
   void write(const std::string& data, bool add_nullterm = true);
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
   void write(const std::vector<T>& data);
 
   // Return the offset of the underlying buffer. Useful for error checking

--- a/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
+++ b/src/libhictk/binary_buffer/include/hictk/impl/binary_buffer_impl.hpp
@@ -11,7 +11,7 @@
 
 namespace hictk {
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline T BinaryBuffer::read() {
   static_assert(sizeof(char) == 1);
   assert(_i < _buffer.size());
@@ -22,12 +22,12 @@ inline T BinaryBuffer::read() {
   return x;
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::read(T &buff) {
   buff = read<T>();
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::read(std::vector<T> &buff) {
   read(reinterpret_cast<char *>(buff.data()), sizeof(T) * buff.size());
 }
@@ -51,19 +51,25 @@ inline std::string BinaryBuffer::getline(char delim) {
   return std::string{view.substr(0, pos)};
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+inline void BinaryBuffer::write(const char *data, std::size_t count, bool add_nullterm) {
+  _buffer.append(data, count);
+  if (add_nullterm) {
+    _buffer.append("\0", 1);
+  }
+}
+
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 inline void BinaryBuffer::write(T data) {
-  static_assert(sizeof(char) == 1);
-  _buffer.append(reinterpret_cast<const char *>(&data), sizeof(T));
+  write(reinterpret_cast<const char *>(&data), sizeof(T), false);
 }
 
 inline void BinaryBuffer::write(const std::string &data, bool add_nullterm) {
-  _buffer.append(data.c_str(), data.size() + add_nullterm);
+  write(data.c_str(), data.size() + add_nullterm, false);
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
 void BinaryBuffer::write(const std::vector<T> &data) {
-  _buffer.append(reinterpret_cast<const char *>(data.data()), data.size() * sizeof(T));
+  write(reinterpret_cast<const char *>(data.data()), data.size() * sizeof(T), false);
 }
 
 inline std::size_t BinaryBuffer::operator()() const noexcept { return _i; }

--- a/src/libhictk/common/include/hictk/static_binary_buffer.hpp
+++ b/src/libhictk/common/include/hictk/static_binary_buffer.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+
+namespace hictk::internal {
+
+template <typename... Ts>
+class StaticBinaryBuffer {
+  static_assert((std::is_arithmetic_v<Ts> && ...), "Not all types are arithmetic!");
+
+  // We are allocating one extra byte so that we can store '\0' as the last value
+  // (just in case the string_view returned by operator()() is passed to some function
+  // that expects null-terminated strings)
+  static constexpr std::size_t SIZE = (sizeof(Ts) + ... + 1);
+
+  alignas(std::uint64_t) std::array<char, SIZE> _buff{'\0'};
+
+ public:
+  StaticBinaryBuffer() = default;
+  inline explicit StaticBinaryBuffer(const Ts &...inputs) noexcept {
+    std::size_t i = 0;
+    (
+        [&] {
+          // This is just a best-effort attempt to make the compiler do the data copying at compile
+          // time.
+          // When this fails, and the copying is done at run time, this implementation will be much
+          // slower than e.g. std::memcopy.
+          // However, StaticBinaryBuffer should never be used to more than say a few dozens of bytes
+          // worth of data, so even if the data copying ends up being slow, it shouldn't be a big
+          // deal.
+          const auto *src = reinterpret_cast<const char *>(&inputs);
+          for (std::size_t j = 0; j < sizeof(inputs); ++j, ++i) {
+            _buff[i] = *(src + j);
+          }
+        }(),
+        ...);
+
+    assert(!_buff.empty());
+    _buff.back() = '\0';
+  }
+
+  constexpr std::string_view operator()() const noexcept {
+    return std::string_view{_buff.data(), _buff.size() - 1};
+  }
+};
+
+}  // namespace hictk::internal

--- a/src/libhictk/common/include/hictk/type_traits.hpp
+++ b/src/libhictk/common/include/hictk/type_traits.hpp
@@ -28,6 +28,16 @@ struct is_string
 template <typename T>
 constexpr bool is_string_v = is_string<T>::value;
 
+// Note that this will not work for types with non-type template arguments (e.g. std::array)
+template <typename T, template <typename...> typename Template>
+struct is_specialization : std::false_type {};
+
+template <template <typename...> typename Template, typename... Args>
+struct is_specialization<Template<Args...>, Template> : std::true_type {};
+
+template <typename T, template <typename...> typename Template>
+constexpr bool is_specialization_v = is_specialization<T, Template>::value;
+
 template <typename T, typename Enabler = void>
 struct is_map : std::false_type {};
 

--- a/src/libhictk/cooler/include/hictk/cooler/impl/utils_copy_impl.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/impl/utils_copy_impl.hpp
@@ -29,12 +29,12 @@
 namespace hictk::cooler::utils {
 
 inline void copy(std::string_view uri1, std::string_view uri2) {
-  const auto [path2, grp2] = cooler::parse_cooler_uri(uri2);
+  const auto uri = cooler::parse_cooler_uri(uri2);
   if (std::filesystem::exists(uri2) && utils::is_cooler(uri2)) {
     throw std::runtime_error("destination already contains a Cooler");
   }
-  const HighFive::File dest(path2, HighFive::File::OpenOrCreate);
-  return copy(uri1, RootGroup{dest.getGroup(grp2)});
+  const HighFive::File dest(uri.file_path, HighFive::File::OpenOrCreate);
+  return copy(uri1, RootGroup{dest.getGroup(uri.group_path)});
 }
 
 inline void copy(std::string_view uri1, RootGroup dest) {
@@ -46,8 +46,8 @@ inline void copy(std::string_view uri1, RootGroup dest) {
     /* Attempt to open an existing HDF5 file first. Need to open the dst file
          before the src file just in case that the dst and src are the same file
     */
-    const auto [path1, grp1] = cooler::parse_cooler_uri(uri1);
-    const HighFive::File fin(path1, HighFive::File::ReadOnly);
+    const auto uri = cooler::parse_cooler_uri(uri1);
+    const HighFive::File fin(uri.file_path, HighFive::File::ReadOnly);
 
     /* create property to pass copy options */
     auto ocpl_id = H5Pcreate(H5P_OBJECT_COPY);
@@ -96,12 +96,12 @@ inline void copy(std::string_view uri1, RootGroup dest) {
       }
     };
 
-    for (const auto &obj : fin.getGroup(grp1).listObjectNames()) {
-      copy_h5_object(fin.getGroup(grp1), dest(), obj);
+    for (const auto &obj : fin.getGroup(uri.group_path).listObjectNames()) {
+      copy_h5_object(fin.getGroup(uri.group_path), dest(), obj);
     }
 
-    for (const auto &attr : fin.getGroup(grp1).listAttributeNames()) {
-      copy_h5_attribute(fin.getGroup(grp1), dest(), std::string{attr});
+    for (const auto &attr : fin.getGroup(uri.group_path).listAttributeNames()) {
+      copy_h5_attribute(fin.getGroup(uri.group_path), dest(), std::string{attr});
     }
 
     /* close propertis */

--- a/src/libhictk/filestream/include/hictk/filestream.hpp
+++ b/src/libhictk/filestream/include/hictk/filestream.hpp
@@ -8,90 +8,193 @@
 #include <fstream>
 #include <ios>
 #include <iosfwd>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace hictk::filestream {
 
+template <typename Mutex = std::mutex>
 class FileStream {
+  static_assert(sizeof(char) == 1, "char must be 1 byte wide!");
+  static_assert(sizeof(float) == 4, "float must be 4 bytes wide!");
+  static_assert(sizeof(double) == 8, "double must be 8 bytes wide!");
+
   std::string _path{};
+  mutable std::shared_ptr<Mutex> _mtx{};
   mutable std::ifstream _ifs{};
   mutable std::ofstream _ofs{};
-  std::size_t _file_size{};
+  std::streamsize _file_size{};
+
+  static const std::ifstream::openmode _ifs_flags{std::ios::in | std::ios::binary};
+  static const std::ofstream::openmode _ofs_flags{std::ios::in | std::ios::out | std::ios::binary};
 
  public:
   FileStream() = default;
-  explicit FileStream(std::string path, std::ios::openmode mode = std::ios::in);
-  static FileStream create(std::string path);
+  // pass nullptr as mtx to disable file locking
+  FileStream(std::string path, std::shared_ptr<Mutex> mtx, std::ios::openmode mode = std::ios::in);
+  static FileStream create(std::string path, std::shared_ptr<Mutex> mtx);
+
+  FileStream(const FileStream &other) = delete;
+  FileStream(FileStream &&other) noexcept;
+
+  ~FileStream() noexcept = default;
+
+  FileStream &operator=(const FileStream &other) = delete;
+  FileStream &operator=(FileStream &&other) noexcept;
 
   [[nodiscard]] const std::string &path() const noexcept;
-  [[nodiscard]] std::size_t size() const;
+
+  void close();
+
+  // seek*
+  void seekg(std::streampos position);
+  void unsafe_seekg(std::streampos position);
+  void seekp(std::streampos position);
+  void unsafe_seekp(std::streampos position);
 
   void seekg(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
-  [[nodiscard]] std::size_t tellg() const noexcept;
-
+  void unsafe_seekg(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
   void seekp(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
-  [[nodiscard]] std::size_t tellp() const noexcept;
+  void unsafe_seekp(std::streamoff offset, std::ios::seekdir way = std::ios::beg);
 
-  [[nodiscard]] bool eof() const noexcept;
+  // tell*
+  [[nodiscard]] std::streampos tellg() const;
+  [[nodiscard]] std::streampos unsafe_tellg() const;
+  [[nodiscard]] std::streampos tellp() const;
+  [[nodiscard]] std::streampos unsafe_tellp() const;
+
+  // others
+  [[nodiscard]] std::streamsize size() const;
+  [[nodiscard]] std::streamsize unsafe_size() const;
+
+  [[nodiscard]] bool eof() const;
+  [[nodiscard]] bool unsafe_eof() const;
 
   void flush();
+  void unsafe_flush();
 
-  void read(std::string &buffer, std::size_t count);
+  [[nodiscard]] static std::string get_underlying_os_error();
+
+  // Locks mutex protecting the underlying file streams.
+  // IMPORTANT: while the lock is held, only unsafe_* methods can be used.
+  [[nodiscard]] std::unique_lock<Mutex> lock() const;
+  [[nodiscard]] bool is_locked() const noexcept;
+
+  // read char*
   void read(char *buffer, std::size_t count);
-  void read_append(std::string &buffer, std::size_t count);
+  // this method (as well as all other seek_* methods) return a pair with the offset before seek and
+  // the offset after read/write
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset, char *buffer,
+                                                          std::size_t count,
+                                                          std::ios::seekdir way = std::ios::beg);
+  void unsafe_read(char *buffer, std::size_t count);
 
+  // read std::string
+  [[nodiscard]] std::string read(std::size_t count);
+  void read(std::string &buffer, std::size_t count);
+  void read_append(std::string &buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset,
+                                                          std::string &buffer, std::size_t count,
+                                                          std::ios::seekdir way = std::ios::beg);
+
+  // getline
   bool getline(std::string &buffer, char delim = '\n');
   [[nodiscard]] std::string getline(char delim = '\n');
+  std::tuple<bool, std::streampos, std::streampos> seek_and_getline(
+      std::streamoff offset, std::string &buffer, std::ios::seekdir way = std::ios::beg,
+      char delim = '\n');
+  bool unsafe_getline(std::string &buffer, char delim);
 
-  void write(std::string_view buffer);
-  void write(const char *buffer, std::size_t count);
-
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // read T
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   [[nodiscard]] T read();
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void read(T &buffer);
-
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
-  void write(T buffer);
-
-  template <typename Tin,
-            typename Tout = std::make_signed_t<Tin>,  // NOLINTNEXTLINE(modernize-type-traits)
-            typename std::enable_if<std::is_integral<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename Tout = std::make_signed_t<Tin>,
+            typename std::enable_if_t<std::is_integral_v<Tin>> * = nullptr>
   [[nodiscard]] Tout read_as_signed();
-  template <typename Tin,
-            typename Tout = std::make_unsigned_t<Tin>,  // NOLINTNEXTLINE(modernize-type-traits)
-            typename std::enable_if<std::is_integral<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename Tout = std::make_unsigned_t<Tin>,
+            typename std::enable_if_t<std::is_integral_v<Tin>> * = nullptr>
   [[nodiscard]] Tout read_as_unsigned();
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename Tin, typename std::enable_if<std::is_arithmetic<Tin>::value>::type * = nullptr>
+  template <typename Tin, typename std::enable_if_t<std::is_arithmetic_v<Tin>> * = nullptr>
   [[nodiscard]] double read_as_double();
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_read(T &buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  [[nodiscard]] T unsafe_read();
 
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // read vector<T>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void read(std::vector<T> &buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  [[nodiscard]] std::vector<T> read_vector(std::size_t size);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_read(std::streamoff offset,
+                                                          std::vector<T> &buffer,
+                                                          std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_read(std::vector<T> &buffer);
 
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
+  // write const char*
+  void write(const char *buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           const char *buffer, std::size_t count,
+                                                           std::ios::seekdir way = std::ios::beg);
+  void unsafe_write(const char *buffer, std::size_t count);
+  std::pair<std::streampos, std::streampos> append(const char *buffer, std::size_t count);
+
+  // write std::string
+  void write(std::string_view buffer);
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           std::string_view buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  std::pair<std::streampos, std::streampos> append(std::string_view buffer);
+
+  // write T
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void write(T buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  void unsafe_write(T buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset, T buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> append(T buffer);
+
+  // write vector<T>
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
   void write(const std::vector<T> &buffer);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> seek_and_write(std::streamoff offset,
+                                                           const std::vector<T> &buffer,
+                                                           std::ios::seekdir way = std::ios::beg);
+  template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> * = nullptr>
+  std::pair<std::streampos, std::streampos> append(const std::vector<T> &buffer);
 
-  // NOLINTNEXTLINE(modernize-type-traits)
-  template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type * = nullptr>
-  [[nodiscard]] std::vector<T> read(std::size_t size);
+  void resize(std::streamsize new_size);
 
  private:
   [[nodiscard]] std::streampos new_posg(std::streamoff offset, std::ios::seekdir way);
+  [[nodiscard]] std::streampos new_posg_checked(std::streamoff offset, std::ios::seekdir way);
   [[nodiscard]] std::streampos new_posp(std::streamoff offset, std::ios::seekdir way);
   void update_file_size();
+  void unsafe_update_file_size();
   [[nodiscard]] static std::ifstream open_file_read(const std::string &path,
                                                     std::ifstream::openmode mode);
   [[nodiscard]] static std::ofstream open_file_write(const std::string &path,
                                                      std::ofstream::openmode mode);
+  [[nodiscard]] static std::string get_underlying_os_error(int errno_);
+  static void get_underlying_os_error(int errno_, std::string &buffer);
+
+  template <typename T, typename I1, typename I2>
+  static void validate_read(I1 bytes_read, I2 count_expected,
+                            std::string_view prefix = "FileStream::read*()");
 };
 }  // namespace hictk::filestream
 

--- a/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
+++ b/src/libhictk/filestream/include/hictk/impl/filestream_impl.hpp
@@ -4,232 +4,745 @@
 
 #pragma once
 
+#ifdef _WIN32
+// clang-format off
+#include <windows.h>
+#include <errhandlingapi.h>
+// clang-format on
+#endif
+
 #include <cassert>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iosfwd>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "hictk/common.hpp"
+#include "hictk/type_traits.hpp"
 
 namespace hictk::filestream {
 
-inline FileStream::FileStream(std::string path, std::ios::openmode mode)
+template <typename Mutex>
+inline FileStream<Mutex>::FileStream(std::string path, std::shared_ptr<Mutex> mtx,
+                                     std::ios::openmode mode)
     : _path(std::move(path)),
-      _ifs(open_file_read(_path, std::ios::in | std::ios::binary | std::ios::ate)),
-      _ofs(mode & std::ios::out
-               ? open_file_write(_path, std::ios::in | std::ios::out | std::ios::binary)
-               : std::ofstream{}),
-      _file_size(static_cast<std::size_t>(_ifs.tellg())) {
-  _ifs.seekg(0, std::ios::beg);
+      _mtx(std::move(mtx)),
+      _ifs(open_file_read(_path, _ifs_flags | std::ios::ate)),
+      _ofs(mode & std::ios::out ? open_file_write(_path, _ofs_flags) : std::ofstream{}),
+      _file_size(unsafe_tellg()) {
+  unsafe_seekg(0);
 }
 
-inline FileStream FileStream::create(std::string path) {
+template <typename Mutex>
+inline FileStream<Mutex> FileStream<Mutex>::create(std::string path, std::shared_ptr<Mutex> mtx) {
   if (std::filesystem::exists(path)) {
     throw std::runtime_error("file \"" + path + "\" already exists");
   }
+
   FileStream fs{};
   fs._path = std::move(path);
-  fs._ofs = open_file_write(fs._path, std::ios::trunc | std::ios::binary);
-  fs._ifs = open_file_read(fs._path, std::ios::binary);
+  fs._mtx = std::move(mtx);
+  fs._ofs = open_file_write(fs._path, _ofs_flags | std::ios::trunc);
+  fs._ifs = open_file_read(fs._path, _ifs_flags);
 
   return fs;
 }
 
-inline const std::string &FileStream::path() const noexcept { return _path; }
+// We need to explicitly define the move constructor to make things compile on older compilers
+// (where std::mutex is not moveable)
+template <typename Mutex>
+inline FileStream<Mutex>::FileStream(FileStream &&other) noexcept
+    : _path(std::move(other._path)),
+      _mtx(std::move(other._mtx)),
+      _ifs(std::move(other._ifs)),
+      _ofs(std::move(other._ofs)),
+      _file_size(other._file_size) {}
 
-inline std::size_t FileStream::size() const { return _file_size; }
-
-inline void FileStream::seekg(std::streamoff offset, std::ios::seekdir way) {
-  const auto new_pos = new_posg(offset, way);
-  if (new_pos < 0 || new_pos >= std::int64_t(size() + 1)) {
-    throw std::runtime_error("caught an attempt of out-of-bound read");
+// We need to explicitly define the move assignment operator to make things compile on older
+// compilers (where std::mutex is not moveable)
+template <typename Mutex>
+inline FileStream<Mutex> &FileStream<Mutex>::operator=(FileStream &&other) noexcept {
+  if (this == &other) {
+    return *this;
   }
+
+  _path = std::move(other._path);
+  _mtx = std::move(other._mtx);
+  _ifs = std::move(other._ifs);
+  _ofs = std::move(other._ofs);
+  _file_size = other._file_size;
+
+  return *this;
+}
+
+template <typename Mutex>
+inline const std::string &FileStream<Mutex>::path() const noexcept {
+  return _path;
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::close() {
+  {
+    [[maybe_unused]] const auto lck = lock();
+    if (_ifs.is_open()) {
+      _ifs.close();
+    }
+    if (_ofs.is_open()) {
+      _ofs.close();
+    }
+  }
+  _mtx.reset();
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::seekg(std::streampos position) {
+  seekg(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekg(std::streampos position) {
+  unsafe_seekg(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::seekp(std::streampos position) {
+  seekp(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekp(std::streampos position) {
+  unsafe_seekp(position, std::ios::beg);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::seekg(std::streamoff offset, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_seekg(offset, way);
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekg(std::streamoff offset, std::ios::seekdir way) {
+  const auto new_pos = new_posg_checked(offset, way);
   _ifs.seekg(new_pos, std::ios::beg);
 }
 
-inline std::size_t FileStream::tellg() const noexcept {
-  assert(_ifs.tellg() >= 0);
-  return static_cast<std::size_t>(_ifs.tellg());
+template <typename Mutex>
+inline void FileStream<Mutex>::seekp(std::streamoff offset, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_seekp(offset, way);
 }
 
-inline void FileStream::seekp(std::streamoff offset, std::ios::seekdir way) {
-  _ofs.seekp(new_posp(offset, way), std::ios::beg);
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_seekp(std::streamoff offset, std::ios::seekdir way) {
+  const auto pos = new_posp(offset, way);
+  _ofs.seekp(pos, std::ios::beg);
+  _file_size = std::max(static_cast<std::streamsize>(pos), _file_size);
 }
 
-inline std::size_t FileStream::tellp() const noexcept {
-  assert(_ofs.tellp() >= 0);
-  return static_cast<std::size_t>(_ofs.tellp());
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::tellg() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_tellg();
 }
 
-inline bool FileStream::eof() const noexcept { return _ifs.eof(); }
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::unsafe_tellg() const {
+  const auto offset = _ifs.tellg();
+  if (offset >= 0) {
+    return offset;
+  }
+  throw std::runtime_error("FileStream::tellg() called on a bad file handle: " +
+                           get_underlying_os_error());
+}
 
-inline void FileStream::flush() { _ofs.flush(); }
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::tellp() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_tellp();
+}
 
-inline void FileStream::read(std::string &buffer, std::size_t count) {
-  buffer.resize(count);
-  if (count > 0) {
-    return read(&buffer.front(), count);
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::unsafe_tellp() const {
+  const auto offset = _ofs.tellp();
+  if (offset >= 0) {
+    return offset;
+  }
+  throw std::runtime_error("FileStream::tellp() called on a bad file handle: " +
+                           get_underlying_os_error());
+}
+
+template <typename Mutex>
+inline std::streamsize FileStream<Mutex>::size() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_size();
+}
+
+template <typename Mutex>
+inline std::streamsize FileStream<Mutex>::unsafe_size() const {
+  if constexpr (ndebug_not_defined()) {
+    if (path().empty()) {
+      return _file_size;
+    }
+    _ofs.flush();
+    const auto offset = unsafe_tellg();
+    _ifs.seekg(0, std::ios::end);
+    const auto effective_size = unsafe_tellg();
+    _ifs.seekg(offset, std::ios::beg);
+    if (effective_size != _file_size) {
+      throw std::runtime_error("FileStream is corrupted: expected size " +
+                               std::to_string(_file_size) + ", found " +
+                               std::to_string(effective_size));
+    }
+  }
+  return _file_size;
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::eof() const {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_eof();
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::unsafe_eof() const {
+  return _ifs.eof();
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::flush() {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_flush();
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_flush() {
+  _ofs.flush();
+}
+
+template <typename Mutex>
+inline std::unique_lock<Mutex> FileStream<Mutex>::lock() const {
+  if (!_mtx) {
+    return {};
+  }
+  return std::unique_lock{*_mtx};
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::is_locked() const noexcept {
+  if (!_mtx) {
+    return false;
+  }
+  // clang8 complains if this expression is written in a single line
+  const std::unique_lock lck{*_mtx, std::try_to_lock};
+  return !lck.owns_lock();
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::read(std::size_t count) {
+  std::string buffer(count, '\0');
+  read(buffer, count);
+  return buffer;
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::read(char *buffer, std::size_t count) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_read(buffer, count);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, char *buffer, std::size_t count, std::ios::seekdir way) {
+  auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  unsafe_read(buffer, count);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_read(char *buffer, std::size_t count) {
+  const auto offset1 = unsafe_tellg();
+  _ifs.read(buffer, static_cast<std::streamsize>(count));
+  const auto bytes_read = unsafe_tellg() - offset1;
+  validate_read<char>(bytes_read, count, "FileStream::unsafe_read(char *)");
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::read(std::string &buffer, std::size_t count) {
+  try {
+    buffer.resize(count);
+    if (count == 0) {
+      return;
+    }
+    read(&buffer.front(), count);
+  } catch (...) {
+    buffer.clear();
+    throw;
   }
 }
 
-inline void FileStream::read(char *buffer, std::size_t count) {
-  _ifs.read(buffer, std::int64_t(count));
-}
-
-inline void FileStream::read_append(std::string &buffer, std::size_t count) {
+template <typename Mutex>
+inline void FileStream<Mutex>::read_append(std::string &buffer, std::size_t count) {
   if (count == 0) {
     return;
   }
-  const auto buff_size = buffer.size();
-  buffer.resize(buffer.size() + count);
 
-  _ifs.read(&(*buffer.begin()) + buff_size, std::int64_t(count));
+  const auto buff_size = buffer.size();
+  try {
+    buffer.resize(buffer.size() + count);
+
+    [[maybe_unused]] const auto lck = lock();
+    const auto offset1 = unsafe_tellg();
+    _ifs.read(&(*buffer.begin()) + buff_size, static_cast<std::streamsize>(count));
+    const auto bytes_read = static_cast<std::size_t>(unsafe_tellg() - offset1);
+    validate_read<char>(bytes_read, count, "FileStream::read_append(std::string &)");
+  } catch (...) {
+    buffer.resize(buff_size);
+    throw;
+  }
 }
 
-inline bool FileStream::getline(std::string &buffer, char delim) {
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, std::string &buffer, std::size_t count, std::ios::seekdir way) {
+  try {
+    buffer.resize(count);
+    return seek_and_read(offset, buffer.data(), buffer.size(), way);
+  } catch (...) {
+    buffer.clear();
+    throw;
+  }
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::getline(std::string &buffer, char delim) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_getline(buffer, delim);
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::getline(char delim) {
+  std::string buffer{};
+  getline(buffer, delim);
+  return buffer;
+}
+
+template <typename Mutex>
+inline std::tuple<bool, std::streampos, std::streampos> FileStream<Mutex>::seek_and_getline(
+    std::streamoff offset, std::string &buffer, std::ios::seekdir way, char delim) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  const auto status = unsafe_getline(buffer, delim);
+  return std::make_tuple(status, offset1, unsafe_tellg());
+}
+
+template <typename Mutex>
+inline bool FileStream<Mutex>::unsafe_getline(std::string &buffer, char delim) {
   buffer.clear();
-  if (eof()) {
+  if (unsafe_eof()) {
     _ifs.setstate(std::ios::badbit);
   }
   try {
     return !!std::getline(_ifs, buffer, delim);
-  } catch (const std::exception &) {
-    if (_ifs.eof() && !_ifs.bad()) {
+  } catch (...) {
+    if (unsafe_eof() && !_ifs.bad()) {
       return !!_ifs;
     }
     throw;
   }
 }
 
-inline void FileStream::write(std::string_view buffer) {
-  return write(buffer.data(), buffer.size());
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline T FileStream<Mutex>::read() {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_read<T>();
 }
 
-inline void FileStream::write(const char *buffer, std::size_t count) {
-  _ofs.write(buffer, std::int64_t(count));
-  _file_size = std::max(static_cast<std::size_t>(_ofs.tellp()), _file_size);
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::read(T &buffer) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_read(buffer);
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::read(T &buffer) {
-  static_assert(sizeof(char) == 1);
-  return read(reinterpret_cast<char *>(&buffer), sizeof(T));
-}
-
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline T FileStream::read() {
-  T buffer{};
-  read(buffer);
-  return buffer;
-}
-
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::write(T buffer) {
-  static_assert(sizeof(char) == 1);
-  return write(reinterpret_cast<const char *>(&buffer), sizeof(T));
-}
-
-template <typename Tin, typename Tout,
-          typename std::enable_if<std::is_integral<Tin>::value>::type *>
-inline Tout FileStream::read_as_signed() {
-  auto tmp = read<Tin>();
+template <typename Mutex>
+template <typename Tin, typename Tout, typename std::enable_if_t<std::is_integral_v<Tin>> *>
+inline Tout FileStream<Mutex>::read_as_signed() {
   return conditional_static_cast<Tout>(read<Tin>());
 }
 
-template <typename Tin, typename Tout,
-          typename std::enable_if<std::is_integral<Tin>::value>::type *>
-inline Tout FileStream::read_as_unsigned() {
+template <typename Mutex>
+template <typename Tin, typename Tout, typename std::enable_if_t<std::is_integral_v<Tin>> *>
+inline Tout FileStream<Mutex>::read_as_unsigned() {
   return conditional_static_cast<Tout>(read<Tin>());
 }
 
-template <typename Tin, typename std::enable_if<std::is_arithmetic<Tin>::value>::type *>
-inline double FileStream::read_as_double() {
+template <typename Mutex>
+template <typename Tin, typename std::enable_if_t<std::is_arithmetic_v<Tin>> *>
+inline double FileStream<Mutex>::read_as_double() {
   return conditional_static_cast<double>(read<Tin>());
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::read(std::vector<T> &buffer) {
-  static_assert(sizeof(char) == 1);
-  return read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_read(T &buffer) {
+  unsafe_read(reinterpret_cast<char *>(&buffer), sizeof(T));
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline void FileStream::write(const std::vector<T> &buffer) {
-  static_assert(sizeof(char) == 1);
-  return write(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline T FileStream<Mutex>::unsafe_read() {
+  T buffer{};
+  unsafe_read(buffer);
+  return buffer;
 }
 
-template <typename T, typename std::enable_if<std::is_fundamental<T>::value>::type *>
-inline std::vector<T> FileStream::read(std::size_t size) {
-  assert(size != 0);
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::read(std::vector<T> &buffer) {
+  read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::vector<T> FileStream<Mutex>::read_vector(std::size_t size) {
   std::vector<T> buffer(size);
   read(buffer);
   return buffer;
 }
 
-inline std::string FileStream::getline(char delim) {
-  std::string buffer{};
-  getline(buffer, delim);
-  return buffer;
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_read(
+    std::streamoff offset, std::vector<T> &buffer, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellg();
+  unsafe_seekg(offset, way);
+  unsafe_read(buffer);
+  const auto num_bytes = buffer.size() * sizeof(T);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(num_bytes));
 }
 
-inline std::streampos FileStream::new_posg(std::streamoff offset, std::ios::seekdir way) {
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_read(std::vector<T> &buffer) {
+  unsafe_read(reinterpret_cast<char *>(&(*buffer.begin())), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::write(const char *buffer, std::size_t count) {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_write(buffer, count);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, const char *buffer, std::size_t count, std::ios::seekdir way) {
+  [[maybe_unused]] const auto lck = lock();
+  const auto offset1 = unsafe_tellp();
+  unsafe_seekp(offset, way);
+  unsafe_write(buffer, count);
+  return std::make_pair(offset1, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_write(const char *buffer, std::size_t count) {
+  _ofs.write(buffer, static_cast<std::streamsize>(count));
+  _file_size = std::max(static_cast<std::streamsize>(unsafe_tellp()), _file_size);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(const char *buffer,
+                                                                           std::size_t count) {
+  const auto lck = lock();
+  unsafe_seekp(0, std::ios::end);
+  const auto offset = unsafe_tellp();
+  unsafe_write(buffer, count);
+
+  return std::make_pair(offset, offset + static_cast<std::streamoff>(count));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::write(std::string_view buffer) {
+  return write(buffer.data(), buffer.size());
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, std::string_view buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, buffer.data(), buffer.size(), way);
+}
+
+template <typename Mutex>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(
+    std::string_view buffer) {
+  return append(buffer.data(), buffer.size());
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::write(T buffer) {
+  [[maybe_unused]] const auto lck = lock();
+  return unsafe_write(buffer);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::unsafe_write(T buffer) {
+  return unsafe_write(reinterpret_cast<const char *>(&buffer), sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(T buffer) {
+  return append(reinterpret_cast<const char *>(&buffer), sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, T buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, reinterpret_cast<const char *>(&buffer), sizeof(T), way);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline void FileStream<Mutex>::write(const std::vector<T> &buffer) {
+  return write(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::seek_and_write(
+    std::streamoff offset, const std::vector<T> &buffer, std::ios::seekdir way) {
+  return seek_and_write(offset, reinterpret_cast<const char *>(buffer.data()),
+                        buffer.size() * sizeof(T), way);
+}
+
+template <typename Mutex>
+template <typename T, typename std::enable_if_t<std::is_arithmetic_v<T>> *>
+inline std::pair<std::streampos, std::streampos> FileStream<Mutex>::append(
+    const std::vector<T> &buffer) {
+  return append(reinterpret_cast<const char *>(buffer.data()), buffer.size() * sizeof(T));
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::resize(std::streamsize new_size) {
+  [[maybe_unused]] const auto lck = lock();
+  if (!_ofs.is_open()) {
+    throw std::runtime_error("FileStream::resize() was called on a file opened in read-only mode");
+  }
+
+  if (new_size != _file_size) {
+    std::filesystem::resize_file(_path, conditional_static_cast<std::uintmax_t>(new_size));
+    const auto current_ifs_offset = unsafe_tellg();
+    const auto current_ofs_offset = unsafe_tellp();
+    _ifs = open_file_read(_path, _ifs_flags);
+    _ofs = open_file_write(_path, _ofs_flags);
+    _file_size = new_size;
+
+    unsafe_seekg(std::min(conditional_static_cast<std::streampos>(_file_size),
+                          conditional_static_cast<std::streampos>(current_ifs_offset)));
+    unsafe_seekp(std::min(conditional_static_cast<std::streampos>(_file_size),
+                          conditional_static_cast<std::streampos>(current_ofs_offset)));
+  }
+}
+
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posg(std::streamoff offset, std::ios::seekdir way) {
   switch (way) {
     case std::ios::beg:
-      return static_cast<std::streampos>(offset);
+      return offset;
     case std::ios::cur:
-      return std::int64_t(tellg()) + offset;
+      return unsafe_tellg() + offset;
     case std::ios::end:
-      return std::int64_t(_file_size) + offset;
+      return static_cast<std::streampos>(_file_size) - offset;
     default:
       HICTK_UNREACHABLE_CODE;
   }
 }
 
-inline std::streampos FileStream::new_posp(std::streamoff offset, std::ios::seekdir way) {
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posg_checked(std::streamoff offset,
+                                                          std::ios::seekdir way) {
+  const auto new_pos = new_posg(offset, way);
+  if (new_pos < 0 || new_pos >= static_cast<std::streampos>(_file_size + 1)) {
+    auto msg1 = "new_posg_checked returned invalid offset=" + std::to_string(new_pos) +
+                "; offset not between 0 and " + std::to_string(_file_size + 1);
+    if (const auto msg2 = get_underlying_os_error(); msg1 != "Success") {
+      msg1 += msg2;
+    }
+
+    throw std::runtime_error(msg1);
+  }
+  return new_pos;
+}
+
+template <typename Mutex>
+inline std::streampos FileStream<Mutex>::new_posp(std::streamoff offset, std::ios::seekdir way) {
   switch (way) {
     case std::ios::beg:
-      return static_cast<std::streampos>(offset);
+      return offset;
     case std::ios::cur:
-      return std::int64_t(tellp()) + offset;
+      return unsafe_tellp() + offset;
     case std::ios::end:
-      return std::int64_t(_file_size) + offset;
+      return static_cast<std::streampos>(_file_size) - offset;
     default:
       HICTK_UNREACHABLE_CODE;
   }
 }
-
-inline void FileStream::update_file_size() {
-  const auto offset = _ifs.tellg();
-  _ifs.seekg(0, std::ios::end);
-  _file_size = std::max(static_cast<std::size_t>(_ifs.tellg()), _file_size);
-  _ifs.seekg(offset, std::ios::beg);
+template <typename Mutex>
+inline void FileStream<Mutex>::update_file_size() {
+  [[maybe_unused]] const auto lck = lock();
+  unsafe_update_file_size();
 }
 
-inline std::ifstream FileStream::open_file_read(const std::string &path,
-                                                std::ifstream::openmode mode) {
+template <typename Mutex>
+inline void FileStream<Mutex>::unsafe_update_file_size() {
+  unsafe_flush();
+  const auto offset = unsafe_tellg();
+  unsafe_seekg(0, std::ios::end);
+  _file_size = std::max(static_cast<std::streamsize>(unsafe_tellg()), _file_size);
+  unsafe_seekg(offset);
+}
+
+template <typename Mutex>
+inline std::ifstream FileStream<Mutex>::open_file_read(const std::string &path,
+                                                       std::ifstream::openmode mode) {
   std::ifstream fs;
   fs.exceptions(fs.exceptions() | std::ios::failbit | std::ios::badbit);
   fs.open(path, mode);
   return fs;
 }
 
-inline std::ofstream FileStream::open_file_write(const std::string &path,
-                                                 std::ofstream::openmode mode) {
+template <typename Mutex>
+inline std::ofstream FileStream<Mutex>::open_file_write(const std::string &path,
+                                                        std::ofstream::openmode mode) {
   std::ofstream fs;
   fs.exceptions(fs.exceptions() | std::ios::failbit | std::ios::badbit);
   fs.open(path, mode);
   return fs;
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::get_underlying_os_error() {
+  return get_underlying_os_error(errno);
+}
+
+template <typename Mutex>
+inline std::string FileStream<Mutex>::get_underlying_os_error(int errno_) {
+  std::string buffer(256, '\0');
+  get_underlying_os_error(errno_, buffer);
+  return buffer;
+}
+
+template <typename Mutex>
+inline void FileStream<Mutex>::get_underlying_os_error([[maybe_unused]] int errno_,
+                                                       std::string &buffer) {
+#ifdef _WIN32
+  if (const auto ec = GetLastError(); ec != 0) {
+    LPSTR msg_buffer = nullptr;
+
+    const auto msg_size = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, ec, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&msg_buffer, 0, nullptr);
+
+    buffer.assign(msg_buffer, msg_size);
+    LocalFree(msg_buffer);
+    return;
+  }
+#endif
+
+  if (errno_ == 0) {
+    buffer = "Success";
+    return;
+  }
+#if defined(_GNU_SOURCE)
+  buffer = strerror_r(errno_, buffer.data(), buffer.size());
+#elif defined(_WIN32)
+  buffer.resize(std::max(buffer.capacity(), std::size_t{1024}), '\0');
+  const int status = strerror_s(buffer.data(), buffer.size(), errno_);
+#else
+  buffer.resize(std::max(buffer.capacity(), std::size_t{1024}), '\0');
+  const int status = strerror_r(errno_, buffer.data(), buffer.size());
+#endif
+
+#ifndef _GNU_SOURCE
+  switch (status) {
+    case 0: {
+      // strerror_r/s call was successful
+      if (const auto pos = buffer.find('\0'); pos != std::string::npos) {
+        if (pos == 0) {
+          // this should never happen
+          buffer.clear();
+        } else {
+          buffer.resize(pos);
+        }
+      }
+      return;
+    }
+    case EINVAL: {
+#ifdef _WIN32
+      buffer = "strerror_s: unknown errno: " + std::to_string(errno_);
+#else
+      buffer = "strerror_r: unknown errno: " + std::to_string(errno_);
+#endif
+      return;
+    }
+    case ERANGE: {
+      buffer.resize(buffer.size() * 2, '\0');
+      return get_underlying_os_error(errno_, buffer);
+    }
+    default: {
+      assert(status < 0);
+      // on old versions of glibc error is communicated through a new errno value
+      get_underlying_os_error(errno, buffer);
+      buffer = "strerror_r: " + buffer;
+    }
+  }
+#endif
+}
+
+template <typename Mutex>
+template <typename T, typename I1, typename I2>
+inline void FileStream<Mutex>::validate_read(I1 bytes_read, I2 count_expected,
+                                             std::string_view prefix) {
+  static_assert(std::is_arithmetic_v<T>);
+  static_assert(std::is_integral_v<I1> || is_specialization_v<I1, std::fpos>);
+  static_assert(std::is_integral_v<I2> || is_specialization_v<I1, std::fpos>);
+
+  if constexpr (std::is_signed_v<I1>) {
+    assert(bytes_read >= 0);
+  }
+  if constexpr (std::is_signed_v<I2>) {
+    assert(count_expected >= 0);
+  }
+
+  const auto bytes_expected = conditional_static_cast<std::size_t>(count_expected) * sizeof(T);
+  if (conditional_static_cast<std::size_t>(bytes_read) == bytes_expected) {
+    return;
+  }
+
+  assert(conditional_static_cast<std::size_t>(bytes_read) < bytes_expected);
+  throw std::runtime_error(std::string{prefix} + " failed: expected to read " +
+                           std::to_string(bytes_expected) + " bytes, but only read " +
+                           std::to_string(bytes_read));
 }
 
 }  // namespace hictk::filestream

--- a/src/libhictk/hic/include/hictk/hic/file_reader.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_reader.hpp
@@ -28,7 +28,7 @@ namespace hictk::hic::internal {
 
 class HiCFileReader {
   using Decompressor = UniquePtrWithDeleter<libdeflate_decompressor>;
-  std::shared_ptr<filestream::FileStream> _fs{};
+  std::shared_ptr<filestream::FileStream<>> _fs{};
   std::shared_ptr<const HiCHeader> _header{};
   std::string _strbuff{};
   Decompressor _decompressor{init_decompressor()};
@@ -66,10 +66,10 @@ class HiCFileReader {
       MatrixType matrix_type, MatrixUnit wanted_unit, std::uint32_t wanted_resolution);
   [[nodiscard]] std::vector<balancing::Method> list_avail_normalizations_v9();
 
-  [[nodiscard]] static MatrixType readMatrixType(filestream::FileStream &fs, std::string &buff);
-  [[nodiscard]] static balancing::Method readNormalizationMethod(filestream::FileStream &fs,
+  [[nodiscard]] static MatrixType readMatrixType(filestream::FileStream<> &fs, std::string &buff);
+  [[nodiscard]] static balancing::Method readNormalizationMethod(filestream::FileStream<> &fs,
                                                                  std::string &buff);
-  [[nodiscard]] static MatrixUnit readMatrixUnit(filestream::FileStream &fs, std::string &buff);
+  [[nodiscard]] static MatrixUnit readMatrixUnit(filestream::FileStream<> &fs, std::string &buff);
 
   [[nodiscard]] Index read_index(std::int64_t fileOffset, const Chromosome &chrom1,
                                  const Chromosome &chrom2, MatrixUnit wantedUnit,
@@ -79,10 +79,10 @@ class HiCFileReader {
   [[nodiscard]] static bool checkMagicString(std::string url) noexcept;
 
  private:
-  [[nodiscard]] static filestream::FileStream openStream(std::string url);
+  [[nodiscard]] static filestream::FileStream<> openStream(std::string url);
   // reads the header, storing the positions of the normalization vectors and returning the
   // masterIndexPosition pointer
-  [[nodiscard]] static HiCHeader readHeader(filestream::FileStream &fs);
+  [[nodiscard]] static HiCHeader readHeader(filestream::FileStream<> &fs);
 
   [[nodiscard]] std::vector<double> readExpectedVector(std::int64_t nValues);
   [[nodiscard]] std::vector<double> readNormalizationFactors(std::uint32_t wantedChrom);
@@ -100,7 +100,7 @@ class HiCFileReader {
 
   [[nodiscard]] std::int64_t readNValues();
   [[nodiscard]] bool checkMagicString();
-  [[nodiscard]] static bool checkMagicString(filestream::FileStream &fs);
+  [[nodiscard]] static bool checkMagicString(filestream::FileStream<> &fs);
   [[nodiscard]] std::int64_t masterOffset() const noexcept;
 
   [[nodiscard]] static auto init_decompressor() -> Decompressor;

--- a/src/libhictk/hic/include/hictk/hic/file_writer.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer.hpp
@@ -35,12 +35,13 @@
 #include "hictk/hic/header.hpp"
 #include "hictk/hic/interaction_block.hpp"
 #include "hictk/hic/interaction_to_block_mapper.hpp"
+#include "hictk/hic/serialized_block_pqueue.hpp"
 #include "hictk/tmpdir.hpp"
 
 namespace hictk::hic::internal {
 
 class HiCSectionOffsets {
-  std::streamoff _position{};
+  std::streampos _position{};
   std::size_t _size{};
 
  public:
@@ -48,10 +49,13 @@ class HiCSectionOffsets {
   template <typename I1, typename I2>
   HiCSectionOffsets(I1 start_, I2 size_);
 
-  [[nodiscard]] std::streamoff start() const noexcept;
-  [[nodiscard]] std::streamoff end() const noexcept;
+  [[nodiscard]] std::streampos start() const noexcept;
+  [[nodiscard]] std::streampos end() const noexcept;
   [[nodiscard]] std::size_t size() const noexcept;
-  [[nodiscard]] std::size_t& size() noexcept;
+
+  void extend(std::size_t s) noexcept;
+  void extend(std::streamoff s) noexcept;
+  void set_size(std::size_t new_size) noexcept;
 };
 
 struct BlockIndexKey {
@@ -99,15 +103,17 @@ class HiCFileWriter {
     std::uint64_t nnz{};
   };
 
-  filestream::FileStream _fs{};
+  filestream::FileStream<> _fs{};
   std::filesystem::path _tmpdir{};
 
   using BinTables = phmap::flat_hash_map<std::uint32_t, std::shared_ptr<const BinTable>>;
   using BlockIndex = phmap::btree_map<BlockIndexKey, phmap::btree_set<MatrixBlockMetadata>>;
   using BlockMappers = phmap::flat_hash_map<std::uint32_t, HiCInteractionToBlockMapper>;
+  using CompressedBlockPQueue = SerializedBlockPQueue<HiCInteractionToBlockMapper::BlockID>;
 
   HiCHeader _header{};
   BinTables _bin_tables{};
+  std::mutex _block_index_mtx{};
   BlockIndex _block_index{};
   BlockMappers _block_mappers{};
 
@@ -149,8 +155,7 @@ class HiCFileWriter {
       std::string_view assembly_ = "unknown", std::size_t n_threads = 1,
       std::size_t chunk_size = 10'000'000,
       const std::filesystem::path& tmpdir = hictk::internal::TmpDir::default_temp_directory_path(),
-      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false,
-      std::size_t buffer_size = 32'000'000);
+      std::uint32_t compression_lvl = 11, bool skip_all_vs_all_matrix = false);
 
   [[nodiscard]] std::string_view path() const noexcept;
   [[nodiscard]] const Reference& chromosomes() const noexcept;
@@ -175,7 +180,7 @@ class HiCFileWriter {
   void serialize();
 
  private:
-  [[nodiscard]] static HiCHeader read_header(filestream::FileStream& fs);
+  [[nodiscard]] static HiCHeader read_header(filestream::FileStream<>& fs);
   [[nodiscard]] static HiCHeader init_header(std::string_view path, Reference chromosomes,
                                              std::vector<std::uint32_t> resolutions,
                                              std::string_view assembly,
@@ -187,7 +192,7 @@ class HiCFileWriter {
                                                            const BinTables& bin_tables,
                                                            std::size_t chunk_size,
                                                            int compression_lvl) -> BlockMappers;
-  [[nodiscard]] BS::thread_pool init_tpool(std::size_t n_threads);
+  [[nodiscard]] static BS::thread_pool init_tpool(std::size_t n_threads);
 
   // Write header
   void write_header();
@@ -196,16 +201,17 @@ class HiCFileWriter {
 
   // Write pixels
   void write_pixels(bool skip_all_vs_all_matrix);
-  auto write_pixels(const Chromosome& chrom1, const Chromosome& chrom2) -> HiCSectionOffsets;
-  auto write_pixels(const Chromosome& chrom1, const Chromosome& chrom2, std::uint32_t resolution)
-      -> HiCSectionOffsets;
+  HiCSectionOffsets write_pixels(const Chromosome& chrom1, const Chromosome& chrom2);
+  HiCSectionOffsets write_pixels(const Chromosome& chrom1, const Chromosome& chrom2,
+                                 std::uint32_t resolution);
   void write_all_matrix(std::uint32_t target_num_bins = 500);
 
-  auto write_interaction_block(std::uint64_t block_id, const Chromosome& chrom1,
-                               const Chromosome& chrom2, std::uint32_t resolution,
-                               const MatrixInteractionBlock<float>& blk) -> HiCSectionOffsets;
-  auto write_interaction_blocks(const Chromosome& chrom1, const Chromosome& chrom2,
-                                std::uint32_t resolution) -> Stats;
+  [[nodiscard]] HiCSectionOffsets write_interaction_block(
+      std::streampos offset, std::uint64_t block_id, const Chromosome& chrom1,
+      const Chromosome& chrom2, std::uint32_t resolution, const MatrixInteractionBlock<float>& blk);
+  [[nodiscard]] auto write_interaction_blocks(std::streampos offset, const Chromosome& chrom1,
+                                              const Chromosome& chrom2, std::uint32_t resolution)
+      -> std::pair<HiCSectionOffsets, Stats>;
 
   // Normalization
   void add_norm_vector(const NormalizationVectorIndexBlock& blk, const balancing::Weights& weights,
@@ -223,11 +229,11 @@ class HiCFileWriter {
   void add_footer(const Chromosome& chrom1, const Chromosome& chrom2);
   void write_footer_size();
 
-  void write_empty_expected_values();
-  void write_empty_normalized_expected_values();
-  void compute_and_write_expected_values();
-  void compute_and_write_normalized_expected_values();
-  void write_norm_vectors();
+  HiCSectionOffsets write_empty_expected_values();
+  HiCSectionOffsets write_empty_normalized_expected_values();
+  HiCSectionOffsets compute_and_write_expected_values();
+  HiCSectionOffsets compute_and_write_normalized_expected_values();
+  HiCSectionOffsets write_norm_vectors();
 
   void finalize(bool compute_expected_values = false);
 
@@ -249,20 +255,20 @@ class HiCFileWriter {
 
   void read_offsets();
 
+  [[nodiscard]] const phmap::btree_set<HiCInteractionToBlockMapper::BlockID>&
+  initialize_block_queue(const Chromosome& chrom1, const Chromosome& chrom2,
+                         std::uint32_t resolution) const noexcept;
+
   // Methods to be called from worker threads
   auto merge_and_compress_blocks_thr(
-      HiCInteractionToBlockMapper& mapper, std::mutex& mapper_mtx,
-      std::queue<std::uint64_t>& block_id_queue, std::mutex& block_id_queue_mtx,
-      moodycamel::BlockingConcurrentQueue<HiCInteractionToBlockMapper::BlockID>& block_queue,
-      phmap::flat_hash_map<std::uint64_t, std::string>& serialized_block_tank,
-      std::mutex& serialized_block_tank_mtx, std::atomic<bool>& early_return,
-      std::uint64_t stop_token) -> Stats;
-  void write_compressed_blocks_thr(
-      const Chromosome& chrom1, const Chromosome& chrom2, std::uint32_t resolution,
-      std::queue<std::uint64_t>& block_id_queue, std::mutex& block_id_queue_mtx,
-      phmap::flat_hash_map<std::uint64_t, std::string>& serialized_block_tank,
-      std::mutex& serialized_block_tank_mtx, std::atomic<bool>& early_return,
-      std::uint64_t stop_token);
+      std::size_t thread_id, const Chromosome& chrom1, const Chromosome& chrom2,
+      std::uint32_t resolution, HiCInteractionToBlockMapper& block_mapper, std::mutex& mapper_mtx,
+      std::atomic<const HiCInteractionToBlockMapper::BlockID*>& first_bid,
+      const HiCInteractionToBlockMapper::BlockID* last_bid,
+      CompressedBlockPQueue& compressed_block_queue, std::atomic<bool>& early_return) -> Stats;
+  void write_compressed_blocks(const Chromosome& chrom1, const Chromosome& chrom2,
+                               std::uint32_t resolution,
+                               std::vector<CompressedBlockPQueue::Record>& compressed_blocks);
 };
 }  // namespace hictk::hic::internal
 

--- a/src/libhictk/hic/include/hictk/hic/file_writer_data_structures.hpp
+++ b/src/libhictk/hic/include/hictk/hic/file_writer_data_structures.hpp
@@ -150,7 +150,10 @@ struct ExpectedValuesBlock {
   [[nodiscard]] bool operator<(const ExpectedValuesBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static ExpectedValuesBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static ExpectedValuesBlock deserialize(std::streampos offset,
+                                                       filestream::FileStream<>& fs);
+  [[nodiscard]] static ExpectedValuesBlock unsafe_deserialize(std::streampos offset,
+                                                              filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#expected-value-vectors
@@ -162,7 +165,10 @@ class ExpectedValues {
   [[nodiscard]] const phmap::btree_set<ExpectedValuesBlock>& expectedValues() const noexcept;
   void emplace(const ExpectedValuesBlock& evb, bool force_overwrite = false);
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static ExpectedValues deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static ExpectedValues deserialize(std::streampos offset,
+                                                  filestream::FileStream<>& fs);
+  [[nodiscard]] static ExpectedValues unsafe_deserialize(std::streampos offset,
+                                                         filestream::FileStream<>& fs);
 };
 
 struct NormalizedExpectedValuesBlock {
@@ -184,7 +190,10 @@ struct NormalizedExpectedValuesBlock {
   [[nodiscard]] bool operator<(const NormalizedExpectedValuesBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizedExpectedValuesBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizedExpectedValuesBlock deserialize(std::streampos offset,
+                                                                 filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizedExpectedValuesBlock unsafe_deserialize(
+      std::streampos offset, filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#normalized-expected-value-vectors
@@ -197,7 +206,10 @@ class NormalizedExpectedValues {
       const noexcept;
   void emplace(const NormalizedExpectedValuesBlock& evb, bool force_overwrite = false);
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizedExpectedValues deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizedExpectedValues deserialize(std::streampos offset,
+                                                            filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizedExpectedValues unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<>& fs);
 };
 
 struct NormalizationVectorIndexBlock {
@@ -217,7 +229,10 @@ struct NormalizationVectorIndexBlock {
   [[nodiscard]] bool operator<(const NormalizationVectorIndexBlock& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizationVectorIndexBlock deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizationVectorIndexBlock deserialize(std::streampos offset,
+                                                                 filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizationVectorIndexBlock unsafe_deserialize(
+      std::streampos offset, filestream::FileStream<>& fs);
 };
 
 // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#normalization-vector-index
@@ -231,7 +246,10 @@ class NormalizationVectorIndex {
   void emplace_back(NormalizationVectorIndexBlock blk);
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static NormalizationVectorIndex deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static NormalizationVectorIndex deserialize(std::streampos offset,
+                                                            filestream::FileStream<>& fs);
+  [[nodiscard]] static NormalizationVectorIndex unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<>& fs);
 };
 
 }  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/header.hpp
+++ b/src/libhictk/hic/include/hictk/hic/header.hpp
@@ -34,7 +34,9 @@ struct HiCHeader {
   bool operator!=(const HiCHeader& other) const noexcept;
 
   [[nodiscard]] std::string serialize(BinaryBuffer& buffer, bool clear = true) const;
-  [[nodiscard]] static HiCHeader deserialize(filestream::FileStream& fs);
+  [[nodiscard]] static HiCHeader deserialize(std::streampos offset, filestream::FileStream<>& fs);
+  [[nodiscard]] static HiCHeader unsafe_deserialize(std::streampos offset,
+                                                    filestream::FileStream<>& fs);
 };
 
 }  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_data_structures_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_data_structures_impl.hpp
@@ -374,8 +374,11 @@ template <typename N>
 inline void MatrixInteractionBlock<N>::compress(const std::string &buffer_in,
                                                 std::string &buffer_out,
                                                 libdeflate_compressor &compressor) {
-  assert(buffer_out.capacity() != 0);
   buffer_out.resize(buffer_out.capacity());
+  if (buffer_out.empty()) {
+    buffer_out.resize(libdeflate_deflate_compress_bound(&compressor, buffer_in.size()));
+  }
+
   while (true) {
     const auto compressed_size = libdeflate_zlib_compress(
         &compressor, buffer_in.data(), buffer_in.size(), buffer_out.data(), buffer_out.size());
@@ -384,7 +387,9 @@ inline void MatrixInteractionBlock<N>::compress(const std::string &buffer_in,
       break;
     }
 
-    buffer_out.resize(buffer_out.size() * 2);
+    const auto new_size = std::max(
+        buffer_out.size() * 2, libdeflate_deflate_compress_bound(&compressor, buffer_in.size()));
+    buffer_out.resize(new_size);
   }
 }
 
@@ -464,22 +469,31 @@ inline std::string ExpectedValuesBlock::serialize(BinaryBuffer &buffer, bool cle
   return buffer.get();
 }
 
-inline ExpectedValuesBlock ExpectedValuesBlock::deserialize(filestream::FileStream &fs) {
+inline ExpectedValuesBlock ExpectedValuesBlock::deserialize(std::streampos offset,
+                                                            filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline ExpectedValuesBlock ExpectedValuesBlock::unsafe_deserialize(std::streampos offset,
+                                                                   filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   ExpectedValuesBlock evb{};
 
   try {
-    evb.unit = fs.getline('\0');
-    fs.read(evb.binSize);
-    const auto nValues = static_cast<std::size_t>(fs.read<std::int64_t>());
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(evb.unit, '\0');
+    fs.unsafe_read(evb.binSize);
+    const auto nValues = static_cast<std::size_t>(fs.unsafe_read<std::int64_t>());
     evb.value.resize(nValues);
-    fs.read(evb.value);
-    const auto nChrScaleFactors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_read(evb.value);
+    const auto nChrScaleFactors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     evb.chrIndex.resize(nChrScaleFactors);
     evb.chrScaleFactor.resize(nChrScaleFactors);
 
     for (std::size_t i = 0; i < nChrScaleFactors; ++i) {
-      evb.chrIndex.emplace_back(fs.read<std::int32_t>());
-      evb.chrScaleFactor.emplace_back(fs.read<float>());
+      evb.chrIndex.emplace_back(fs.unsafe_read<std::int32_t>());
+      evb.chrScaleFactor.emplace_back(fs.unsafe_read<float>());
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -535,13 +549,22 @@ inline std::string ExpectedValues::serialize(BinaryBuffer &buffer, bool clear) c
   return buffer.get();
 }
 
-inline ExpectedValues ExpectedValues::deserialize(filestream::FileStream &fs) {
+inline ExpectedValues ExpectedValues::deserialize(std::streampos offset,
+                                                  filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline ExpectedValues ExpectedValues::unsafe_deserialize(std::streampos offset,
+                                                         filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   ExpectedValues evs{};
 
   try {
-    const auto nExpectedValueVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nExpectedValueVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nExpectedValueVectors; ++i) {
-      evs.emplace(ExpectedValuesBlock::deserialize(fs), true);
+      evs.emplace(ExpectedValuesBlock::unsafe_deserialize(fs.unsafe_tellg(), fs), true);
     }
   } catch (const std::exception &e) {
     throw std::runtime_error("an error occurred while deserializing an ExpectedValues object: " +
@@ -615,25 +638,32 @@ inline std::string NormalizedExpectedValuesBlock::serialize(BinaryBuffer &buffer
 
   return buffer.get();
 }
-
 inline NormalizedExpectedValuesBlock NormalizedExpectedValuesBlock::deserialize(
-    filestream::FileStream &fs) {
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizedExpectedValuesBlock NormalizedExpectedValuesBlock::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizedExpectedValuesBlock nevb{};
 
   try {
-    nevb.type = fs.getline('\0');
-    nevb.unit = fs.getline('\0');
-    fs.read(nevb.binSize);
-    const auto nValues = static_cast<std::size_t>(fs.read<std::int64_t>());
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(nevb.type, '\0');
+    fs.unsafe_getline(nevb.unit, '\0');
+    fs.unsafe_read(nevb.binSize);
+    const auto nValues = static_cast<std::size_t>(fs.unsafe_read<std::int64_t>());
     nevb.value.resize(nValues);
-    fs.read(nevb.value);
-    const auto nChrScaleFactors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_read(nevb.value);
+    const auto nChrScaleFactors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     nevb.chrIndex.resize(nChrScaleFactors);
     nevb.chrScaleFactor.resize(nChrScaleFactors);
 
     for (std::size_t i = 0; i < nChrScaleFactors; ++i) {
-      nevb.chrIndex.emplace_back(fs.read<std::int32_t>());
-      nevb.chrScaleFactor.emplace_back(fs.read<float>());
+      nevb.chrIndex.emplace_back(fs.unsafe_read<std::int32_t>());
+      nevb.chrScaleFactor.emplace_back(fs.unsafe_read<float>());
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -686,13 +716,22 @@ inline std::string NormalizedExpectedValues::serialize(BinaryBuffer &buffer, boo
   return buffer.get();
 }
 
-inline NormalizedExpectedValues NormalizedExpectedValues::deserialize(filestream::FileStream &fs) {
+inline NormalizedExpectedValues NormalizedExpectedValues::deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizedExpectedValues NormalizedExpectedValues::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizedExpectedValues nevs{};
 
   try {
-    const auto nNormExpectedValueVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nNormExpectedValueVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nNormExpectedValueVectors; ++i) {
-      nevs.emplace(NormalizedExpectedValuesBlock::deserialize(fs), true);
+      nevs.emplace(NormalizedExpectedValuesBlock::unsafe_deserialize(fs.unsafe_tellg(), fs), true);
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(
@@ -750,16 +789,24 @@ inline std::string NormalizationVectorIndexBlock::serialize(BinaryBuffer &buffer
 }
 
 inline NormalizationVectorIndexBlock NormalizationVectorIndexBlock::deserialize(
-    filestream::FileStream &fs) {
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizationVectorIndexBlock NormalizationVectorIndexBlock::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizationVectorIndexBlock nvib{};
 
   try {
-    nvib.type = fs.getline('\0');
-    nvib.chrIdx = fs.read<std::int32_t>();
-    nvib.unit = fs.getline('\0');
-    nvib.binSize = fs.read<std::int32_t>();
-    nvib.position = fs.read<std::int64_t>();
-    nvib.nBytes = fs.read<std::int64_t>();
+    fs.unsafe_seekg(offset);
+    fs.unsafe_getline(nvib.type, '\0');
+    nvib.chrIdx = fs.unsafe_read<std::int32_t>();
+    fs.unsafe_getline(nvib.unit, '\0');
+    nvib.binSize = fs.unsafe_read<std::int32_t>();
+    nvib.position = fs.unsafe_read<std::int64_t>();
+    nvib.nBytes = fs.unsafe_read<std::int64_t>();
   } catch (const std::exception &e) {
     throw std::runtime_error(
         "an error occurred while deserializing a NormalizationVectorIndexBlock object: " +
@@ -802,13 +849,22 @@ inline std::string NormalizationVectorIndex::serialize(BinaryBuffer &buffer, boo
   return buffer.get();
 }
 
-inline NormalizationVectorIndex NormalizationVectorIndex::deserialize(filestream::FileStream &fs) {
+inline NormalizationVectorIndex NormalizationVectorIndex::deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  [[maybe_unused]] const auto lck = fs.lock();
+  return unsafe_deserialize(offset, fs);
+}
+
+inline NormalizationVectorIndex NormalizationVectorIndex::unsafe_deserialize(
+    std::streampos offset, filestream::FileStream<> &fs) {
+  assert(offset >= 0);
   NormalizationVectorIndex nvi{};
 
   try {
-    const auto nNormVectors = static_cast<std::size_t>(fs.read<std::int32_t>());
+    fs.unsafe_seekg(offset);
+    const auto nNormVectors = static_cast<std::size_t>(fs.unsafe_read<std::int32_t>());
     for (std::size_t i = 0; i < nNormVectors; ++i) {
-      nvi.emplace_back(NormalizationVectorIndexBlock::deserialize(fs));
+      nvi.emplace_back(NormalizationVectorIndexBlock::unsafe_deserialize(fs.unsafe_tellg(), fs));
     }
   } catch (const std::exception &e) {
     throw std::runtime_error(

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
@@ -41,7 +41,9 @@
 #include "hictk/hic.hpp"
 #include "hictk/hic/common.hpp"
 #include "hictk/hic/index.hpp"
+#include "hictk/hic/serialized_block_pqueue.hpp"
 #include "hictk/reference.hpp"
+#include "hictk/static_binary_buffer.hpp"
 #include "hictk/transformers/coarsen.hpp"
 #include "hictk/version.hpp"
 
@@ -49,21 +51,42 @@ namespace hictk::hic::internal {
 
 template <typename I1, typename I2>
 inline HiCSectionOffsets::HiCSectionOffsets(I1 start_, I2 size_)
-    : _position(conditional_static_cast<std::streamoff>(start_)),
+    : _position(conditional_static_cast<std::streampos>(start_)),
       _size(conditional_static_cast<std::size_t>(size_)) {
-  static_assert(std::is_integral_v<I1>);
-  static_assert(std::is_integral_v<I2>);
+  static_assert(std::is_integral_v<I1> || is_specialization_v<I1, std::fpos>);
+  static_assert(std::is_integral_v<I2> || is_specialization_v<I2, std::fpos>);
+
+  if constexpr (std::is_signed_v<I1> || is_specialization_v<I1, std::fpos>) {
+    if (start_ < 0) {
+      throw std::logic_error(fmt::format(
+          FMT_STRING("start position for HiCSectionOffset cannot be negative, found {}"),
+          static_cast<std::int64_t>(start_)));
+    }
+  }
+  if constexpr (std::is_signed_v<I2> || is_specialization_v<I2, std::fpos>) {
+    assert(size_ >= 0);  // NOLINT
+    if (size_ < 0) {
+      throw std::logic_error(
+          fmt::format(FMT_STRING("size given to HiCSectionOffset cannot be negative, found {}"),
+                      static_cast<std::int64_t>(start_)));
+    }
+  }
 }
 
-inline std::streamoff HiCSectionOffsets::start() const noexcept { return _position; }
+inline std::streampos HiCSectionOffsets::start() const noexcept { return _position; }
 
-inline std::streamoff HiCSectionOffsets::end() const noexcept {
+inline std::streampos HiCSectionOffsets::end() const noexcept {
   return _position + static_cast<std::streamoff>(size());
 }
 
 inline std::size_t HiCSectionOffsets::size() const noexcept { return _size; }
 
-inline std::size_t &HiCSectionOffsets::size() noexcept { return _size; }
+inline void HiCSectionOffsets::extend(std::size_t s) noexcept { _size += s; }
+inline void HiCSectionOffsets::extend(std::streamoff s) noexcept {
+  extend(static_cast<std::size_t>(s));
+}
+
+inline void HiCSectionOffsets::set_size(std::size_t new_size) noexcept { _size = new_size; }
 
 inline bool BlockIndexKey::operator<(const BlockIndexKey &other) const noexcept {
   if (chrom1 != other.chrom1) {
@@ -164,7 +187,7 @@ inline auto MatrixBodyMetadataTank::operator()() const noexcept
 }
 
 inline HiCFileWriter::HiCFileWriter(std::string_view path_, std::size_t n_threads)
-    : _fs(std::string{path_}, std::ios::in | std::ios::out),
+    : _fs(std::string{path_}, std::make_shared<std::mutex>(), std::ios::in | std::ios::out),
       _header(read_header(_fs)),
       _bin_tables(init_bin_tables(chromosomes(), resolutions())),
       _tpool(init_tpool(n_threads)) {
@@ -177,9 +200,8 @@ inline HiCFileWriter::HiCFileWriter(std::string_view path_, Reference chromosome
                                     std::vector<std::uint32_t> resolutions_,
                                     std::string_view assembly_, std::size_t n_threads,
                                     std::size_t chunk_size, const std::filesystem::path &tmpdir,
-                                    std::uint32_t compression_lvl, bool skip_all_vs_all_matrix,
-                                    std::size_t buffer_size)
-    : _fs(filestream::FileStream::create(std::string{path_})),
+                                    std::uint32_t compression_lvl, bool skip_all_vs_all_matrix)
+    : _fs(filestream::FileStream<>::create(std::string{path_}, std::make_shared<std::mutex>())),
       _tmpdir(tmpdir),
       _header(init_header(path_, std::move(chromosomes_), std::move(resolutions_), assembly_,
                           skip_all_vs_all_matrix)),
@@ -187,7 +209,6 @@ inline HiCFileWriter::HiCFileWriter(std::string_view path_, Reference chromosome
       _block_mappers(init_interaction_block_mappers(_tmpdir, _bin_tables, chunk_size, 3)),
       _compression_lvl(compression_lvl),
       _compressor(libdeflate_alloc_compressor(static_cast<std::int32_t>(compression_lvl))),
-      _compression_buffer(buffer_size, '\0'),
       _tpool(init_tpool(n_threads)),
       _skip_all_vs_all_matrix(skip_all_vs_all_matrix) {
   if (!std::filesystem::exists(_tmpdir)) {
@@ -231,21 +252,17 @@ inline void HiCFileWriter::serialize() {
 }
 
 inline void HiCFileWriter::write_header() {
-  assert(_fs.tellp() == 0);
-
   assert(_header.version == 9);
   assert(!chromosomes().empty());
 
   try {
-    const auto offset1 = _fs.tellp();
-    SPDLOG_INFO(FMT_STRING("writing header at offset {}"), offset1);
-    _fs.write(_header.serialize(_bbuffer));
-    const auto offset2 = _fs.tellp();
+    SPDLOG_INFO(FMT_STRING("writing header at offset 0"));
+    const auto section_end = _fs.seek_and_write(0, _header.serialize(_bbuffer)).second;
 
-    _header_section = {offset1, offset2 - offset1};
-    _data_block_section = {offset2, 0};
-    _body_metadata_section = {offset2, 0};
-    _footer_section = {offset2, 0};
+    _header_section = {0, section_end};
+    _data_block_section = {section_end, 0};
+    _body_metadata_section = {section_end, 0};
+    _footer_section = {section_end, 0};
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing the .hic header for file \"{}\" to disk: {}"),
@@ -260,8 +277,7 @@ inline void HiCFileWriter::write_footer_size() {
                         static_cast<std::int64_t>(sizeof(std::int64_t));
 
   try {
-    _fs.seekp(_footer_section.start());
-    _fs.write(nBytesV5);
+    _fs.seek_and_write(_footer_section.start(), nBytesV5);
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing the footer size for file \"{}\" to disk: {}"),
@@ -270,12 +286,12 @@ inline void HiCFileWriter::write_footer_size() {
 }
 
 inline void HiCFileWriter::write_footer_offset() {
-  SPDLOG_DEBUG(FMT_STRING("updating footer offset to {}"), _footer_section.start());
+  SPDLOG_DEBUG(FMT_STRING("updating footer offset to {}"),
+               static_cast<std::int64_t>(_footer_section.start()));
   const auto offset = sizeof("HIC") + sizeof(_header.version);
 
   try {
-    _fs.seekp(offset);
-    _fs.write(conditional_static_cast<std::int64_t>(_footer_section.start()));
+    _fs.seek_and_write(offset, conditional_static_cast<std::int64_t>(_footer_section.start()));
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing the footer offset for file \"{}\" to disk: {}"),
@@ -292,12 +308,11 @@ inline void HiCFileWriter::write_norm_vector_index() {
   const auto normVectorIndexLength = static_cast<std::int64_t>(_norm_vector_index_section.size());
 
   SPDLOG_DEBUG(FMT_STRING("writing normVectorIndex {}:{} at offset {}..."), normVectorIndexPosition,
-               normVectorIndexLength, offset);
+               normVectorIndexLength, static_cast<std::int64_t>(offset));
 
   try {
-    _fs.seekp(offset);
-    _fs.write(normVectorIndexPosition);
-    _fs.write(normVectorIndexLength);
+    const hictk::internal::StaticBinaryBuffer buff{normVectorIndexPosition, normVectorIndexLength};
+    _fs.seek_and_write(offset, buff());
   } catch (const std::exception &e) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("an error occurred while writing the normVectorIndex position and "
@@ -405,14 +420,17 @@ inline void HiCFileWriter::write_all_matrix(std::uint32_t target_num_bins) {
       it->second.emplace_back(std::move(coarsened_pixel));
     });
 
-    const auto offset = _data_block_section.end();
-    _fs.seekp(offset);
+    const auto section_start = _data_block_section.end();
+    auto section_end = section_start;
 
     for (auto &[bid, blk] : blocks) {
       blk.finalize();
-      write_interaction_block(bid, chrom, chrom, target_resolution_scaled, blk);
+      const auto section =
+          write_interaction_block(section_start, bid, chrom, chrom, target_resolution_scaled, blk);
+      section_end = section.end();
     }
-    _data_block_section.size() += _fs.tellp() - static_cast<std::size_t>(offset);
+    assert(section_end >= section_start);
+    _data_block_section.extend(section_end - section_start);
 
     add_body_metadata(target_resolution_scaled, chrom, chrom);
     write_body_metadata();
@@ -500,29 +518,29 @@ inline auto HiCFileWriter::write_pixels(const Chromosome &chrom1, const Chromoso
                                            chrom1.name(), chrom2.name(), res, path(), e.what()));
     }
   }
-  return {_data_block_section.start(),
-          _fs.tellp() - static_cast<std::size_t>(_data_block_section.start())};
+  return {_data_block_section.start(), _fs.tellp() - _data_block_section.start()};
 }
 
 inline void HiCFileWriter::write_body_metadata() {
-  const auto pos = _data_block_section.end();
-  _fs.seekp(pos);
+  const auto section_start = _data_block_section.end();
+  auto pos1 = section_start;
   for (const auto &[chroms, metadata] : _matrix_metadata()) {
     const auto &chrom1 = chroms.chrom1;
     const auto &chrom2 = chroms.chrom2;
     [[maybe_unused]] const auto &num_resolutions = metadata.resolutionMetadata.size();
 
     try {
-      const auto pos1 = _fs.tellp();
       SPDLOG_DEBUG(FMT_STRING("writing MatrixBodyMetadata for {}:{} ({} resolutions) at offset {}"),
-                   chrom1.name(), chrom2.name(), num_resolutions, pos1);
-      _fs.write(metadata.serialize(_bbuffer));
-      const auto pos2 = _fs.tellp();
+                   chrom1.name(), chrom2.name(), num_resolutions, static_cast<std::int64_t>(pos1));
+      const auto pos2 = _fs.seek_and_write(pos1, metadata.serialize(_bbuffer)).second;
+      const auto delta = pos2 - pos1;
       SPDLOG_DEBUG(FMT_STRING("updating MatrixBodyMetadata offset and size for {}:{} ({} "
                               "resolutions) to {} and {}"),
-                   chrom1.name(), chrom2.name(), num_resolutions, pos1, pos2 - pos1);
-      _matrix_metadata.update_offsets(chrom1, chrom2, static_cast<std::streamoff>(pos1),
-                                      pos2 - pos1);
+                   chrom1.name(), chrom2.name(), num_resolutions, static_cast<std::int64_t>(pos1),
+                   static_cast<std::int64_t>(delta));
+      assert(delta >= 0);
+      _matrix_metadata.update_offsets(chrom1, chrom2, pos1, static_cast<std::size_t>(delta));
+      pos1 += delta;
     } catch (const std::exception &e) {
       throw std::runtime_error(
           fmt::format(FMT_STRING("an error occurred while writing the MatrixBodyMetadata for {}:{} "
@@ -531,8 +549,8 @@ inline void HiCFileWriter::write_body_metadata() {
     }
   }
 
-  const auto size = _fs.tellp() - static_cast<std::size_t>(pos);
-  _body_metadata_section = {pos, size};
+  const auto size = static_cast<std::size_t>(section_start - _data_block_section.end());
+  _body_metadata_section = {pos1, size};
 }
 
 inline void HiCFileWriter::add_body_metadata(std::uint32_t resolution, const Chromosome &chrom1,
@@ -584,24 +602,25 @@ inline void HiCFileWriter::add_body_metadata(std::uint32_t resolution, const Chr
 }
 
 inline void HiCFileWriter::write_footers() {
-  const auto offset1 = _body_metadata_section.end();
+  const auto section_start = _body_metadata_section.end();
+  auto offset = section_start;
 
   try {
-    _fs.seekp(offset1);
-    SPDLOG_DEBUG(FMT_STRING("initializing footer section at offset {}"), offset1);
+    SPDLOG_DEBUG(FMT_STRING("initializing footer section at offset {}"),
+                 static_cast<std::int64_t>(offset));
     const std::int64_t nBytesV5 = -1;
     const auto nEntries = static_cast<std::int32_t>(_footers.size());
-    _fs.write(nBytesV5);
-    _fs.write(nEntries);
+    const hictk::internal::StaticBinaryBuffer buff(nBytesV5, nEntries);
+    offset = _fs.seek_and_write(offset, buff()).second;
 
     for (auto &[chroms, footer] : _footers) {
       try {
-        const auto offset = _matrix_metadata.offset(chroms.first, chroms.second);
-        footer.position = conditional_static_cast<std::int64_t>(offset.start());
-        footer.size = static_cast<std::int32_t>(offset.size());
+        const auto section = _matrix_metadata.offset(chroms.first, chroms.second);
+        footer.position = conditional_static_cast<std::int64_t>(section.start());
+        footer.size = static_cast<std::int32_t>(section.size());
         SPDLOG_DEBUG(FMT_STRING("writing FooterMasterIndex for {}:{} at offset {}"),
-                     chroms.first.name(), chroms.second.name(), _fs.tellp());
-        _fs.write(footer.serialize(_bbuffer));
+                     chroms.first.name(), chroms.second.name(), static_cast<std::int64_t>(offset));
+        offset = _fs.seek_and_write(offset, footer.serialize(_bbuffer)).second;
       } catch (const std::exception &e) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("an error occurred while writing the footer for {}:{}: {}"),
@@ -609,14 +628,14 @@ inline void HiCFileWriter::write_footers() {
       }
     }
 
-    write_empty_expected_values();
+    const auto ev_section = write_empty_expected_values();
+
+    _footer_section = {section_start, ev_section.end() - section_start};
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing the footer section to file \"{}\": {}"), path(),
         e.what()));
   }
-
-  _footer_section = {offset1, _fs.tellp() - static_cast<std::size_t>(offset1)};
 }
 
 inline void HiCFileWriter::add_footer(const Chromosome &chrom1, const Chromosome &chrom2) {
@@ -649,15 +668,17 @@ inline void HiCFileWriter::write_norm_vectors_and_norm_expected_values() {
   write_norm_vectors();
 }
 
-inline void HiCFileWriter::write_empty_expected_values() {
+inline HiCSectionOffsets HiCFileWriter::write_empty_expected_values() {
   ExpectedValues ev{};
 
   try {
     const auto offset = _fs.tellp();
-    SPDLOG_DEBUG(FMT_STRING("writing empty expected values section at offset {}..."), offset);
-    _fs.write(ev.serialize(_bbuffer));
+    SPDLOG_DEBUG(FMT_STRING("writing empty expected values section at offset {}..."),
+                 static_cast<std::int64_t>(offset));
+    const auto new_offset = _fs.seek_and_write(offset, ev.serialize(_bbuffer)).second;
 
-    _expected_values_section = {offset, _fs.tellp() - offset};
+    _expected_values_section = {offset, new_offset - offset};
+    return _expected_values_section;
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING(
@@ -666,23 +687,23 @@ inline void HiCFileWriter::write_empty_expected_values() {
   }
 }
 
-inline void HiCFileWriter::write_empty_normalized_expected_values() {
+inline HiCSectionOffsets HiCFileWriter::write_empty_normalized_expected_values() {
   const auto offset = _expected_values_section.end();
   SPDLOG_DEBUG(FMT_STRING("writing empty expected values (normalized) section at offset {}..."),
-               offset);
+               static_cast<std::int64_t>(offset));
   try {
-    _fs.seekp(offset);
     HICTK_DISABLE_WARNING_PUSH
     HICTK_DISABLE_WARNING_USELESS_CAST
-    _fs.write(std::int32_t(0));
+    const auto new_offset = _fs.seek_and_write(offset, std::int32_t(0)).second;  // NOLINT
     HICTK_DISABLE_WARNING_POP
+    _expected_values_norm_section = {offset, new_offset - offset};
+    return _expected_values_norm_section;
   } catch (const std::exception &e) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("an error occurred while writing an empty normalized expected "
                                "values section to file \"{}\": {}"),
                     path(), e.what()));
   }
-  _expected_values_norm_section = {offset, _fs.tellp() - static_cast<std::size_t>(offset)};
 }
 
 inline ExpectedValuesBlock HiCFileWriter::compute_expected_values(std::uint32_t resolution) {
@@ -752,7 +773,7 @@ inline NormalizedExpectedValuesBlock HiCFileWriter::compute_normalized_expected_
   }
 }
 
-inline void HiCFileWriter::compute_and_write_expected_values() {
+inline HiCSectionOffsets HiCFileWriter::compute_and_write_expected_values() {
   assert(_tpool.get_thread_count() != 0);
   ExpectedValues ev{};
 
@@ -770,12 +791,12 @@ inline void HiCFileWriter::compute_and_write_expected_values() {
     const auto offset = _footer_section.end() -
                         conditional_static_cast<std::streamoff>(sizeof(ev.nExpectedValueVectors()));
     SPDLOG_INFO(FMT_STRING("writing {} expected value vectors at offset {}..."),
-                ev.nExpectedValueVectors(), offset);
-    _fs.seekp(offset);
-    _fs.write(ev.serialize(_bbuffer));
+                ev.nExpectedValueVectors(), static_cast<std::int64_t>(offset));
+    const auto new_offset = _fs.seek_and_write(offset, ev.serialize(_bbuffer)).second;
 
-    _expected_values_section = {offset, _fs.tellp() - static_cast<std::size_t>(offset)};
-    _footer_section.size() += _expected_values_section.size() - sizeof(ev.nExpectedValueVectors());
+    _expected_values_section = {offset, new_offset - offset};
+    _footer_section.extend(_expected_values_section.size() - sizeof(ev.nExpectedValueVectors()));
+    return _expected_values_section;
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing expected values to file \"{}\": {}"), path(),
@@ -783,7 +804,7 @@ inline void HiCFileWriter::compute_and_write_expected_values() {
   }
 }
 
-inline void HiCFileWriter::compute_and_write_normalized_expected_values() {
+inline HiCSectionOffsets HiCFileWriter::compute_and_write_normalized_expected_values() {
   assert(_tpool.get_thread_count() != 0);
   NormalizedExpectedValues ev{};
 
@@ -815,11 +836,12 @@ inline void HiCFileWriter::compute_and_write_normalized_expected_values() {
   try {
     const auto offset = _footer_section.end();
     SPDLOG_INFO(FMT_STRING("writing {} normalized expected value vectors at offset {}..."),
-                ev.nNormExpectedValueVectors(), offset);
-    _fs.seekp(offset);
-    _fs.write(ev.serialize(_bbuffer));
+                ev.nNormExpectedValueVectors(), static_cast<std::int64_t>(offset));
+    const auto new_offset = _fs.seek_and_write(offset, ev.serialize(_bbuffer)).second;
 
-    _expected_values_norm_section = {offset, _fs.tellp() - static_cast<std::size_t>(offset)};
+    _fs.flush();
+    _expected_values_norm_section = {offset, new_offset - offset};
+    return _expected_values_norm_section;
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing normalized expected values to file \"{}\": {}"),
@@ -943,29 +965,30 @@ inline void HiCFileWriter::finalize(bool compute_expected_values) {
   }
 }
 
-inline void HiCFileWriter::write_norm_vectors() {
+inline HiCSectionOffsets HiCFileWriter::write_norm_vectors() {
   try {
     const auto offset1 =
         std::max(_expected_values_norm_section.end(), _norm_vector_index_section.start());
-    _fs.seekp(offset1);
 
     if (_normalization_vectors.empty()) {
       SPDLOG_DEBUG(FMT_STRING("writing empty normalization vector section at offset {}..."),
-                   offset1);
+                   static_cast<std::int64_t>(offset1));
     } else {
       SPDLOG_INFO(FMT_STRING("writing {} normalization vectors at offset {}..."),
-                  _normalization_vectors.size(), offset1);
+                  _normalization_vectors.size(), static_cast<std::int64_t>(offset1));
     }
 
     const auto nNormVectors = static_cast<std::int32_t>(_normalization_vectors.size());
-    _fs.write(nNormVectors);
+    auto current_offset = _fs.seek_and_write(offset1, nNormVectors).second;
 
     phmap::btree_map<NormalizationVectorIndexBlock, HiCSectionOffsets> index_offsets{};
     for (const auto &[blk, _] : _normalization_vectors) {
       try {
-        const auto offset2 = _fs.tellp();
-        _fs.write(blk.serialize(_bbuffer));
-        index_offsets.emplace(blk, HiCSectionOffsets{offset2, _fs.tellp() - offset2});
+        const auto section_start = current_offset;
+        current_offset = _fs.seek_and_write(current_offset, blk.serialize(_bbuffer)).second;
+
+        index_offsets.emplace(blk,
+                              HiCSectionOffsets{section_start, current_offset - section_start});
       } catch (const std::exception &e) {
         throw std::runtime_error(fmt::format(
             FMT_STRING(
@@ -975,16 +998,17 @@ inline void HiCFileWriter::write_norm_vectors() {
             path(), e.what()));
       }
     }
-    const auto offset2 = _fs.tellp();
+    const auto offset2 = current_offset;
 
     phmap::btree_map<NormalizationVectorIndexBlock, HiCSectionOffsets> vector_offsets{};
     for (const auto &[blk, weights] : _normalization_vectors) {
       try {
-        const auto offset3 = _fs.tellp();
+        const auto section_start = current_offset;
         const auto nValues = static_cast<std::int64_t>(weights.size());
-        _fs.write(nValues);
-        _fs.write(weights);
-        vector_offsets.emplace(blk, HiCSectionOffsets{offset3, _fs.tellp() - offset3});
+        current_offset = _fs.seek_and_write(current_offset, nValues).second;
+        current_offset = _fs.seek_and_write(current_offset, weights).second;
+        vector_offsets.emplace(blk,
+                               HiCSectionOffsets{section_start, current_offset - section_start});
       } catch (const std::exception &e) {
         throw std::runtime_error(fmt::format(
             FMT_STRING("an error occurred while writing the {} normalization vector for {} "
@@ -994,7 +1018,7 @@ inline void HiCFileWriter::write_norm_vectors() {
       }
     }
 
-    const auto offset4 = _fs.tellp();
+    const auto offset3 = current_offset;
 
     for (const auto &[blk, idx_offsets] : index_offsets) {
       try {
@@ -1002,8 +1026,7 @@ inline void HiCFileWriter::write_norm_vectors() {
         auto new_blk = blk;
         new_blk.position = vect_offsets.start();
         new_blk.nBytes = static_cast<std::int64_t>(vect_offsets.size());
-        _fs.seekp(idx_offsets.start());
-        _fs.write(new_blk.serialize(_bbuffer));
+        _fs.seek_and_write(idx_offsets.start(), new_blk.serialize(_bbuffer));
       } catch (const std::exception &e) {
         throw std::runtime_error(fmt::format(
             FMT_STRING("an error occurred while updating file offsets in the {} "
@@ -1013,12 +1036,14 @@ inline void HiCFileWriter::write_norm_vectors() {
       }
     }
 
-    _norm_vector_index_section = {offset1, offset2 - static_cast<std::size_t>(offset1)};
-    _norm_vectors_section = {offset2, offset4 - static_cast<std::size_t>(offset2)};
+    _norm_vector_index_section = {offset1, offset2 - offset1};
+    _norm_vectors_section = {offset2, offset3 - offset2};
 
     write_norm_vector_index();
-    _fs.seekp(0, std::ios::end);
-    _fs.flush();
+    [[maybe_unused]] const auto lck = _fs.lock();
+    _fs.unsafe_flush();
+    _fs.unsafe_seekp(0, std::ios::end);
+    return {offset1, offset3 - offset1};
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing normalization vectors to file \"{}\": {}"),
@@ -1026,8 +1051,8 @@ inline void HiCFileWriter::write_norm_vectors() {
   }
 }
 
-inline HiCHeader HiCFileWriter::read_header(filestream::FileStream &fs) {
-  return HiCHeader::deserialize(fs);
+inline HiCHeader HiCFileWriter::read_header(filestream::FileStream<> &fs) {
+  return HiCHeader::deserialize(0, fs);
 }
 
 inline HiCHeader HiCFileWriter::init_header(std::string_view path, Reference chromosomes,
@@ -1081,16 +1106,17 @@ inline BS::thread_pool HiCFileWriter::init_tpool(std::size_t n_threads) {
       conditional_static_cast<BS::concurrency_t>(n_threads < 2 ? std::size_t(1) : n_threads)};
 }
 
-inline auto HiCFileWriter::write_pixels(const Chromosome &chrom1, const Chromosome &chrom2,
-                                        std::uint32_t resolution) -> HiCSectionOffsets {
+inline HiCSectionOffsets HiCFileWriter::write_pixels(const Chromosome &chrom1,
+                                                     const Chromosome &chrom2,
+                                                     std::uint32_t resolution) {
   try {
     const auto offset = _data_block_section.end();
-    _fs.seekp(offset);
+    _fs.resize(offset);
 
     SPDLOG_INFO(FMT_STRING("[{} bp] writing pixels for {}:{} matrix at offset {}..."), resolution,
-                chrom1.name(), chrom2.name(), offset);
+                chrom1.name(), chrom2.name(), static_cast<std::int64_t>(offset));
 
-    const auto stats = write_interaction_blocks(chrom1, chrom2, resolution);
+    const auto [section, stats] = write_interaction_blocks(offset, chrom1, chrom2, resolution);
 
     SPDLOG_INFO(FMT_STRING("[{} bp] written {} pixels for {}:{} matrix"), resolution, stats.nnz,
                 chrom1.name(), chrom2.name());
@@ -1101,8 +1127,8 @@ inline auto HiCFileWriter::write_pixels(const Chromosome &chrom1, const Chromoso
       it->second.nnz += stats.nnz;
     }
 
-    _data_block_section.size() += _fs.tellp() - static_cast<std::size_t>(offset);
-    return {offset, _fs.tellp() - static_cast<std::size_t>(offset)};
+    _data_block_section.extend(section.size());
+    return {offset, section.end() - offset};
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while writing pixels for {}:{} to file \"{}\": {}"),
@@ -1110,107 +1136,53 @@ inline auto HiCFileWriter::write_pixels(const Chromosome &chrom1, const Chromoso
   }
 }
 
-inline auto HiCFileWriter::write_interaction_blocks(const Chromosome &chrom1,
+inline auto HiCFileWriter::write_interaction_blocks(std::streampos offset, const Chromosome &chrom1,
                                                     const Chromosome &chrom2,
-                                                    std::uint32_t resolution) -> Stats {
-  auto &mapper = _block_mappers.at(resolution);
-  mapper.finalize();
-
-  const auto block_ids = mapper.chromosome_index().find(std::make_pair(chrom1, chrom2));
-  if (block_ids == mapper.chromosome_index().end()) {
-    SPDLOG_DEBUG(FMT_STRING("no pixels to write for {}:{} matrix at {} resolution"), chrom1.name(),
-                 chrom2.name(), resolution);
-    return {};
-  }
-
-  if (_tpool.get_thread_count() < 3 || block_ids->second.size() == 1) {
-    try {
-      Stats stats{};
-      for (const auto &bid : block_ids->second) {
-        auto blk = mapper.merge_blocks(bid);
-        stats.sum += blk.sum();
-        stats.nnz += blk.size();
-        write_interaction_block(bid.bid, chrom1, chrom2, resolution, std::move(blk));
-      }
-
-      return stats;
-    } catch (const std::exception &e) {
-      throw std::runtime_error(
-          "an error occurred while writing interaction blocks using a single thread: " +
-          std::string{e.what()});
-    }
-  }
+                                                    std::uint32_t resolution)
+    -> std::pair<HiCSectionOffsets, Stats> {
+  assert(offset >= 0);
+  assert(_tpool.get_thread_count() > 0);
 
   try {
-    std::mutex block_id_queue_mtx{};
-    std::queue<std::uint64_t> block_id_queue{};
-    moodycamel::BlockingConcurrentQueue<HiCInteractionToBlockMapper::BlockID> block_queue(
-        block_ids->second.size());
-
-    std::mutex serialized_block_tank_mtx{};
-    phmap::flat_hash_map<std::uint64_t, std::string> serialized_block_tank{
-        block_ids->second.size()};
-    const auto stop_token = std::numeric_limits<std::uint64_t>::max();
-    std::atomic<bool> early_return = false;
-
     std::mutex mapper_mtx{};
+    auto &mapper = _block_mappers.at(resolution);
+    mapper.finalize();
 
-    std::vector<std::future<Stats>> worker_threads{};
-    for (BS::concurrency_t i = 2; i < _tpool.get_thread_count(); ++i) {
-      worker_threads.emplace_back(_tpool.submit_task([&]() {
-        return merge_and_compress_blocks_thr(mapper, mapper_mtx, block_id_queue, block_id_queue_mtx,
-                                             block_queue, serialized_block_tank,
-                                             serialized_block_tank_mtx, early_return, stop_token);
-      }));
+    const auto matrix_block_mapper = mapper.chromosome_index().find(std::make_pair(chrom1, chrom2));
+    if (matrix_block_mapper == mapper.chromosome_index().end()) {
+      SPDLOG_DEBUG(FMT_STRING("no pixels to write for {}:{} matrix at {} resolution"),
+                   chrom1.name(), chrom2.name(), resolution);
+      return {{_fs.size(), 0}, {}};
     }
 
-    auto writer = _tpool.submit_task([&]() {
-      write_compressed_blocks_thr(chrom1, chrom2, resolution, block_id_queue, block_id_queue_mtx,
-                                  serialized_block_tank, serialized_block_tank_mtx, early_return,
-                                  stop_token);
-    });
+    const std::vector block_ids(matrix_block_mapper->second.begin(),
+                                matrix_block_mapper->second.end());
+    CompressedBlockPQueue compressed_block_queue(
+        block_ids.begin(), block_ids.end(),
+        conditional_static_cast<std::size_t>(_tpool.get_thread_count()));
 
-    auto producer = _tpool.submit_task([&]() {
-      try {
-        for (const auto &bid : block_ids->second) {
-          if (early_return) {
-            break;
-          }
+    std::atomic<bool> early_return = false;
 
-          block_queue.enqueue(bid);
-          if (early_return) {
-            break;
-          }
-        }
-        for (std::size_t i = 0; i < worker_threads.size(); ++i) {
-          block_queue.enqueue(HiCInteractionToBlockMapper::BlockID{0, 0, stop_token});
-        }
-      } catch (const std::exception &e) {
-        early_return = true;
-        throw std::runtime_error("an error occurred in the producer thread: " +
-                                 std::string{e.what()});
-      } catch (...) {
-        early_return = true;
-        throw;
-      }
-    });
+    std::atomic first_bid{block_ids.data()};
+    auto *last_bid = block_ids.data() + block_ids.size();
 
-    producer.get();
+    std::vector<std::future<Stats>> workers(
+        conditional_static_cast<std::size_t>(_tpool.get_thread_count()));
+    for (std::size_t i = 0; i < workers.size(); ++i) {
+      workers[i] = _tpool.submit_task([&, i]() {
+        return merge_and_compress_blocks_thr(i, chrom1, chrom2, resolution, mapper, mapper_mtx,
+                                             first_bid, last_bid, compressed_block_queue,
+                                             early_return);
+      });
+    }
 
     Stats stats{};
-    for (auto &worker : worker_threads) {
+    for (auto &worker : workers) {
       const auto partial_stats = worker.get();
       stats.sum += partial_stats.sum;
       stats.nnz += partial_stats.nnz;
     }
-    // signal no more blocks will be enqueued
-    {
-      std::scoped_lock lck(block_id_queue_mtx);
-      block_id_queue.emplace(stop_token);
-    }
-    writer.get();
-
-    return stats;
+    return std::make_pair(HiCSectionOffsets{offset, _fs.tellp() - offset}, stats);
   } catch (const std::exception &e) {
     throw std::runtime_error(
         fmt::format(FMT_STRING("an error occurred while interaction blocks using {} threads: {}"),
@@ -1218,20 +1190,22 @@ inline auto HiCFileWriter::write_interaction_blocks(const Chromosome &chrom1,
   }
 }
 
-inline auto HiCFileWriter::write_interaction_block(std::uint64_t block_id, const Chromosome &chrom1,
+inline auto HiCFileWriter::write_interaction_block(std::streampos offset, std::uint64_t block_id,
+                                                   const Chromosome &chrom1,
                                                    const Chromosome &chrom2,
                                                    std::uint32_t resolution,
                                                    const MatrixInteractionBlock<float> &blk)
     -> HiCSectionOffsets {
-  const auto offset = _fs.tellp();
-
+  assert(offset >= 0);
   std::ignore = blk.serialize(_bbuffer, *_compressor, _compression_buffer);
   SPDLOG_DEBUG(FMT_STRING("writing block #{} for {}:{}:{} at {}:{}"), block_id, chrom1.name(),
-               chrom2.name(), resolution, offset, _compression_buffer.size());
-  _fs.write(_compression_buffer);
+               chrom2.name(), resolution, static_cast<std::int64_t>(offset),
+               _compression_buffer.size());
+  const auto new_offset = _fs.seek_and_write(offset, _compression_buffer).second;
 
-  MatrixBlockMetadata mm{static_cast<std::int32_t>(block_id), static_cast<std::int64_t>(offset),
-                         static_cast<std::int32_t>(_fs.tellp() - offset)};
+  MatrixBlockMetadata mm{static_cast<std::int32_t>(block_id),
+                         conditional_static_cast<std::int64_t>(offset),
+                         static_cast<std::int32_t>(new_offset - offset)};
 
   const BlockIndexKey key{chrom1, chrom2, resolution};
   auto idx = _block_index.find(key);
@@ -1240,7 +1214,7 @@ inline auto HiCFileWriter::write_interaction_block(std::uint64_t block_id, const
   } else {
     _block_index.emplace(key, phmap::btree_set<MatrixBlockMetadata>{std::move(mm)});
   }
-  return {offset, _fs.tellp() - offset};
+  return {offset, new_offset - offset};
 }
 
 inline std::size_t HiCFileWriter::compute_num_bins(const Chromosome &chrom1,
@@ -1277,8 +1251,7 @@ inline void HiCFileWriter::read_norm_expected_values() {
   assert(_expected_values_norm_section.start() != 0);
   try {
     const auto offset = _expected_values_norm_section.start();
-    _fs.seekg(offset);
-    const auto nev = NormalizedExpectedValues::deserialize(_fs);
+    const auto nev = NormalizedExpectedValues::deserialize(offset, _fs);
 
     for (const auto &ev : nev.normExpectedValues()) {
       add_norm_expected_values(ev);
@@ -1294,8 +1267,7 @@ inline void HiCFileWriter::read_norm_vectors() {
   assert(_norm_vector_index_section.start() != 0);
   try {
     const auto offset = _norm_vector_index_section.start();
-    _fs.seekg(offset);
-    const auto nvi = NormalizationVectorIndex::deserialize(_fs);
+    const auto nvi = NormalizationVectorIndex::deserialize(offset, _fs);
 
     for (const auto &blk : nvi.normalizationVectorIndex()) {
       add_norm_vector(blk, read_norm_vector(blk), true);
@@ -1311,14 +1283,14 @@ inline std::vector<float> HiCFileWriter::read_norm_vector(
     const NormalizationVectorIndexBlock &blk) {
   try {
     const auto offset = blk.position;
-    _fs.seekg(offset);
-
     const auto &chrom = chromosomes().at(static_cast<std::uint32_t>(blk.chrIdx));
     const auto bin_size = static_cast<std::size_t>(blk.binSize);
     const auto nValuesExpected = (static_cast<std::size_t>(chrom.size()) + bin_size - 1) / bin_size;
 
+    [[maybe_unused]] auto lck = _fs.lock();
+    _fs.unsafe_seekg(offset);
     // https://github.com/aidenlab/hic-format/blob/master/HiCFormatV9.md#normalization-vector-arrays-1-per-normalization-vector
-    const auto nValues = static_cast<std::size_t>(_fs.read<std::int64_t>());
+    const auto nValues = static_cast<std::size_t>(_fs.unsafe_read<std::int64_t>());
     // We cannot use numValues directly because sometimes hic files have few trailing zeros for some
     // reason
     if (nValues < nValuesExpected) {
@@ -1327,12 +1299,14 @@ inline std::vector<float> HiCFileWriter::read_norm_vector(
     }
 
     std::vector<float> buffer(nValues);
-    _fs.read(buffer);
+    _fs.unsafe_read(buffer);
+    const auto bytes_read = _fs.unsafe_tellg() - offset;
+    lck.unlock();
+
     buffer.resize(nValuesExpected);
-    const auto bytes_read = _fs.tellg() - static_cast<std::size_t>(offset);
-    if (bytes_read != static_cast<std::size_t>(blk.nBytes)) {
-      throw std::runtime_error(
-          fmt::format(FMT_STRING("expected to read {} bytes but read {}"), blk.nBytes, bytes_read));
+    if (bytes_read != blk.nBytes) {
+      throw std::runtime_error(fmt::format(FMT_STRING("expected to read {} bytes but read {}"),
+                                           blk.nBytes, static_cast<std::int64_t>(bytes_read)));
     }
     return buffer;
   } catch (const std::exception &e) {
@@ -1345,25 +1319,26 @@ inline std::vector<float> HiCFileWriter::read_norm_vector(
 
 inline void HiCFileWriter::read_offsets() {
   try {
-    _fs.seekg(0, std::ios::beg);
-    const auto header_start = _fs.tellg();
-    const auto header = HiCHeader::deserialize(_fs);
-    const auto header_end = _fs.tellg();
+    [[maybe_unused]] const auto lck = _fs.lock();
+    _fs.unsafe_seekg(0, std::ios::beg);
+    const auto header_start = _fs.unsafe_tellg();
+    const auto header = HiCHeader::unsafe_deserialize(0, _fs);
+    const auto header_end = _fs.unsafe_tellg();
 
     // read footer offsets
-    _fs.seekg(header.footerPosition);
-    const auto footer_start = _fs.tellg();
-    const auto nBytesV5 = _fs.read<std::int64_t>();
-    _fs.seekg(nBytesV5, std::ios::cur);
-    const auto footer_end = _fs.tellg();
+    _fs.unsafe_seekg(header.footerPosition);
+    const auto footer_start = _fs.unsafe_tellg();
+    const auto nBytesV5 = _fs.unsafe_read<std::int64_t>();
+    _fs.unsafe_seekg(nBytesV5, std::ios::cur);
+    const auto footer_end = _fs.unsafe_tellg();
 
     // read norm expected values offsets
-    const auto norm_expected_values_start = _fs.tellg();
-    const auto nNormExpectedValueVectors = _fs.read<std::int32_t>();
+    const auto norm_expected_values_start = _fs.unsafe_tellg();
+    const auto nNormExpectedValueVectors = _fs.unsafe_read<std::int32_t>();
     for (std::int32_t i = 0; i < nNormExpectedValueVectors; ++i) {
-      std::ignore = NormalizationVectorIndexBlock::deserialize(_fs);
+      std::ignore = NormalizationVectorIndexBlock::unsafe_deserialize(_fs.unsafe_tellg(), _fs);
     }
-    const auto norm_expected_values_end = _fs.tellg();
+    const auto norm_expected_values_end = _fs.unsafe_tellg();
 
     // compute norm vector index offsets
     const auto norm_vector_index_start = header.normVectorIndexPosition;
@@ -1378,7 +1353,7 @@ inline void HiCFileWriter::read_offsets() {
     _norm_vector_index_section = {norm_vector_index_start,
                                   norm_vector_index_end - norm_vector_index_start};
 
-    _fs.seekg(0, std::ios::end);
+    _fs.unsafe_seekg(0, std::ios::end);
   } catch (const std::exception &e) {
     throw std::runtime_error(fmt::format(
         FMT_STRING("an error occurred while reading section offsets from file \"{}\": {}"), path(),
@@ -1396,38 +1371,48 @@ inline std::size_t HiCFileWriter::compute_block_column_count(const Chromosome &c
 }
 
 inline auto HiCFileWriter::merge_and_compress_blocks_thr(
-    HiCInteractionToBlockMapper &mapper, std::mutex &mapper_mtx,
-    std::queue<std::uint64_t> &block_id_queue, std::mutex &block_id_queue_mtx,
-    moodycamel::BlockingConcurrentQueue<HiCInteractionToBlockMapper::BlockID> &block_queue,
-    phmap::flat_hash_map<std::uint64_t, std::string> &serialized_block_tank,
-    std::mutex &serialized_block_tank_mtx, std::atomic<bool> &early_return,
-    std::uint64_t stop_token) -> Stats {
-  SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks thread: start-up..."));
+    std::size_t thread_id, const Chromosome &chrom1, const Chromosome &chrom2,
+    std::uint32_t resolution, HiCInteractionToBlockMapper &block_mapper, std::mutex &mapper_mtx,
+    std::atomic<const HiCInteractionToBlockMapper::BlockID *> &first_bid,
+    const HiCInteractionToBlockMapper::BlockID *last_bid,
+    CompressedBlockPQueue &compressed_block_queue, std::atomic<bool> &early_return) -> Stats {
+  assert(!!first_bid);
+  assert(!!last_bid);
+
+  SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks [tid={}]: start-up..."), thread_id);
+  Stats stats{};
+
   try {
-    HiCInteractionToBlockMapper::BlockID buffer{};
+    std::vector<CompressedBlockPQueue::Record> compressed_blocks_buffer{};
     BinaryBuffer bbuffer{};
-    std::string compression_buffer(16'000'000, '\0');
+    std::string compression_buffer{};
     std::unique_ptr<libdeflate_compressor> libdeflate_compressor(
         libdeflate_alloc_compressor(static_cast<std::int32_t>(_compression_lvl)));
     std::unique_ptr<ZSTD_DCtx_s> zstd_dctx{ZSTD_createDCtx()};
 
-    Stats stats{};
-    while (!early_return) {
-      // dequeue block
-      if (!block_queue.wait_dequeue_timed(buffer, std::chrono::milliseconds(500))) {
-        continue;
+    auto try_dequeue_and_write_blocks = [&]() {
+      compressed_block_queue.dequeue(compressed_blocks_buffer);
+      if (!compressed_blocks_buffer.empty()) {
+        write_compressed_blocks(chrom1, chrom2, resolution, compressed_blocks_buffer);
       }
-      if (buffer.bid == stop_token) {
-        SPDLOG_DEBUG(
-            FMT_STRING("merge_and_compress_blocks thread: processed all blocks. Returning!"));
+    };
+
+    for ([[maybe_unused]] std::size_t blocks_processed = 0; !early_return; ++blocks_processed) {
+      auto *block_idx = first_bid++;
+      if (block_idx >= last_bid) {
+        try_dequeue_and_write_blocks();
+        SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks [tid={}]: no more blocks to be "
+                                "processed: processed a total of {} blocks. Returning!"),
+                     blocks_processed, thread_id);
         return stats;
       }
 
       SPDLOG_DEBUG(
-          FMT_STRING("merge_and_compress_blocks thread: merging partial blocks for block #{}"),
-          buffer.bid);
+          FMT_STRING("merge_and_compress_blocks [tid={}]: merging partial blocks for block #{}"),
+          thread_id, block_idx->bid);
       // read and merge partial blocks
-      auto blk = mapper.merge_blocks(buffer, bbuffer, *zstd_dctx, compression_buffer, mapper_mtx);
+      auto blk = block_mapper.merge_blocks(*block_idx, bbuffer, *zstd_dctx, compression_buffer,
+                                           mapper_mtx);
       stats.nnz += blk.size();
       stats.sum += blk.sum();
 
@@ -1435,101 +1420,71 @@ inline auto HiCFileWriter::merge_and_compress_blocks_thr(
       std::ignore = blk.serialize(bbuffer, *libdeflate_compressor, compression_buffer);
 
       // enqueue serialized block
-      std::scoped_lock lck(serialized_block_tank_mtx, block_id_queue_mtx);
-      SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks thread: done processing block #{}"),
-                   buffer.bid);
-      serialized_block_tank.emplace(std::make_pair(buffer.bid, compression_buffer));
-      block_id_queue.emplace(buffer.bid);
+      SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks [tid={}]: done processing block #{}"),
+                   thread_id, block_idx->bid);
+      while (!compressed_block_queue.try_enqueue(*block_idx, compression_buffer)) {
+        if (early_return) {
+          SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks [tid={}]: early return signal "
+                                  "received: returning immediately!"),
+                       thread_id);
+        }
+
+        try_dequeue_and_write_blocks();
+      }
+      try_dequeue_and_write_blocks();
     }
+
+    try_dequeue_and_write_blocks();
 
     return stats;
   } catch (const std::exception &e) {
     early_return = true;
-    throw std::runtime_error("an error occurred in merge_and_compress_blocks thread: " +
-                             std::string{e.what()});
-
+    throw std::runtime_error(
+        fmt::format(FMT_STRING("an error occurred in merge_and_compress_blocks [tid={}]: {}"),
+                    thread_id, e.what()));
   } catch (...) {
     early_return = true;
     throw;
   }
+
+  if (early_return) {
+    SPDLOG_DEBUG(FMT_STRING("merge_and_compress_blocks [tid={}]: early return signal "
+                            "received: returning immediately!"),
+                 thread_id);
+  }
+
+  return stats;
 }
 
-inline void HiCFileWriter::write_compressed_blocks_thr(
+inline void HiCFileWriter::write_compressed_blocks(
     const Chromosome &chrom1, const Chromosome &chrom2, std::uint32_t resolution,
-    std::queue<std::uint64_t> &block_id_queue, std::mutex &block_id_queue_mtx,
-    phmap::flat_hash_map<std::uint64_t, std::string> &serialized_block_tank,
-    std::mutex &serialized_block_tank_mtx, std::atomic<bool> &early_return,
-    std::uint64_t stop_token) {
-  SPDLOG_DEBUG(FMT_STRING("write_compressed_blocks thread: start-up..."));
-  try {
-    std::string buffer;
+    std::vector<CompressedBlockPQueue::Record> &compressed_blocks) {
+  [[maybe_unused]] const auto lck1 = _fs.lock();
+  _fs.unsafe_seekp(0, std::ios::end);
+  for (auto &[bid, buffer, _] : compressed_blocks) {
+    const auto [file_offset, buffer_size] = [&, &buffer_ = buffer]() {
+      const auto offset = _fs.unsafe_tellp();
+      _fs.unsafe_write(buffer_.data(), buffer_.size());
+      return std::make_pair(static_cast<std::int64_t>(offset),
+                            static_cast<std::int32_t>(buffer_.size()));
+    }();
 
-    while (!early_return) {
-      const auto do_sleep = [&]() {
-        std::scoped_lock lck(block_id_queue_mtx);
-        return block_id_queue.empty();
-      }();
+    buffer.clear();
+    buffer.shrink_to_fit();
 
-      if (do_sleep) {
-        SPDLOG_DEBUG(
-            FMT_STRING("write_compressed_blocks thread: no blocks to consume. Sleeping..."));
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        continue;
-      }
+    MatrixBlockMetadata mm{static_cast<std::int32_t>(bid.bid), file_offset, buffer_size};
+    const BlockIndexKey key{chrom1, chrom2, resolution};
 
-      const auto bid = [&]() {
-        std::scoped_lock lck(block_id_queue_mtx);
-        const auto n = block_id_queue.front();
-        block_id_queue.pop();
-        return n;
-      }();
-
-      if (bid == stop_token) {
-        SPDLOG_DEBUG(FMT_STRING(
-            "write_compressed_blocks thread: no more blocks to be processed. Returning!"));
-        return;
-      }
-
-      SPDLOG_DEBUG(FMT_STRING("write_compressed_blocks thread: waiting for block #{}..."), bid);
-      while (!early_return) {
-        {
-          std::scoped_lock lck(serialized_block_tank_mtx);
-          auto match = serialized_block_tank.find(bid);
-          if (match != serialized_block_tank.end()) {
-            buffer = match->second;
-            serialized_block_tank.erase(match);
-            break;
-          }
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
-      if (early_return) {
-        return;
-      }
-
-      const auto offset = _fs.tellp();
-      SPDLOG_DEBUG(FMT_STRING("writing block #{} for {}:{}:{} at {}:{}"), bid, chrom1.name(),
-                   chrom2.name(), resolution, offset, buffer.size());
-      _fs.write(buffer);
-
-      MatrixBlockMetadata mm{static_cast<std::int32_t>(bid), static_cast<std::int64_t>(offset),
-                             static_cast<std::int32_t>(buffer.size())};
-      const BlockIndexKey key{chrom1, chrom2, resolution};
-      auto idx = _block_index.find(key);
-      if (idx != _block_index.end()) {
-        idx->second.emplace(std::move(mm));
-      } else {
-        _block_index.emplace(key, phmap::btree_set<MatrixBlockMetadata>{std::move(mm)});
-      }
+    [[maybe_unused]] const std::scoped_lock lck2(_block_index_mtx);
+    auto idx = _block_index.find(key);
+    if (idx != _block_index.end()) {
+      idx->second.emplace(std::move(mm));
+    } else {
+      _block_index.emplace(key, phmap::btree_set<MatrixBlockMetadata>{std::move(mm)});
     }
-  } catch (const std::exception &e) {
-    early_return = true;
-    throw std::runtime_error("an error occurred in write_compressed_blocks thread: " +
-                             std::string{e.what()});
 
-  } catch (...) {
-    early_return = true;
-    throw;
+    SPDLOG_DEBUG(FMT_STRING("wrote block #{} for {}:{}:{} at {}:{}"), bid, chrom1.name(),
+                 chrom2.name(), resolution, file_offset, buffer_size);
   }
 }
 

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -127,6 +127,16 @@ inline bool HiCInteractionToBlockMapper::BlockID::operator<(const BlockID &other
   return bid < other.bid;
 }
 
+inline bool HiCInteractionToBlockMapper::BlockID::operator>(const BlockID &other) const noexcept {
+  if (chrom1_id != other.chrom1_id) {
+    return chrom1_id > other.chrom1_id;
+  }
+  if (chrom2_id != other.chrom2_id) {
+    return chrom2_id > other.chrom2_id;
+  }
+  return bid > other.bid;
+}
+
 inline bool HiCInteractionToBlockMapper::BlockID::operator==(const BlockID &other) const noexcept {
   return chrom1_id == other.chrom1_id && chrom2_id == other.chrom2_id && bid == other.bid;
 }
@@ -149,7 +159,7 @@ inline HiCInteractionToBlockMapper::HiCInteractionToBlockMapper(
 
 inline HiCInteractionToBlockMapper::~HiCInteractionToBlockMapper() noexcept {
   try {
-    _fs = filestream::FileStream();
+    _fs.close();
     std::filesystem::remove(_path);
   } catch (...) {
   }
@@ -293,7 +303,7 @@ inline auto HiCInteractionToBlockMapper::block_index() const noexcept -> const B
 }
 
 inline auto HiCInteractionToBlockMapper::chromosome_index() const noexcept
-    -> const ChromosomeIndexMap & {
+    -> const MatrixIndexMap & {
   return _chromosome_index;
 }
 
@@ -476,7 +486,7 @@ inline std::vector<Pixel<float>> HiCInteractionToBlockMapper::fetch_pixels(
 
 inline void HiCInteractionToBlockMapper::write_blocks() {
   if (!std::filesystem::exists(_path)) {
-    _fs = filestream::FileStream::create(_path.string());
+    _fs = filestream::FileStream<>::create(_path.string(), std::make_shared<std::mutex>());
   }
   SPDLOG_DEBUG(FMT_STRING("writing {} pixels to file {}..."), _pending_pixels, _path);
   for (auto &[bid, blk] : _blocks) {

--- a/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "hictk/common.hpp"
+
+namespace hictk::hic::internal {
+template <typename BlockID>
+inline SerializedBlockPQueue<BlockID>::Record::operator bool() const noexcept {
+  return status == Status::SUCCESS;
+}
+
+template <typename BlockID>
+template <typename It>
+inline SerializedBlockPQueue<BlockID>::SerializedBlockPQueue(It first_bid, It last_bid,
+                                                             std::size_t producers_,
+                                                             std::size_t capacity_)
+    : _block_ids(first_bid, last_bid), _producers(producers_) {
+  if (_block_ids.empty()) {
+    _capacity = 0;
+    return;
+  }
+
+  _capacity =
+      std::clamp(capacity_ == 0 ? 3 * _producers : capacity_, std::size_t{2}, std::size_t{32});
+  std::sort(_block_ids.begin(), _block_ids.end(), std::greater{});
+
+  SPDLOG_DEBUG(FMT_STRING("initialized a BlockPQueue with capacity blocks with bids {}-{}"),
+               _capacity, _block_ids.back(), _block_ids.front());
+}
+
+template <typename BlockID>
+inline std::size_t SerializedBlockPQueue<BlockID>::size() const {
+  [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+  return _buff.size();
+}
+
+template <typename BlockID>
+inline std::size_t SerializedBlockPQueue<BlockID>::capacity() const noexcept {
+  return _capacity;
+}
+
+template <typename BlockID>
+inline bool SerializedBlockPQueue<BlockID>::try_enqueue(const BlockID& block_id,
+                                                        const std::string& serialized_block,
+                                                        std::chrono::milliseconds timeout) {
+  const auto expiration = std::chrono::steady_clock::now() + timeout;
+  while (HICTK_LIKELY(std::chrono::steady_clock::now() < expiration)) {
+    {
+      [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+      assert(!_block_ids.empty());
+      assert(block_id == _block_ids.back() || block_id > _block_ids.back());
+      if (HICTK_LIKELY(_buff.size() < _capacity - 1) || block_id == _block_ids.back()) {
+        [[maybe_unused]] const auto inserted = _buff.emplace(block_id, serialized_block).second;
+        assert(inserted);
+        SPDLOG_DEBUG(
+            FMT_STRING("SerializedBlockPQueue::try_enqueue(): successfully enqueued block {}"),
+            block_id);
+        return true;
+      }
+    }
+    SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::try_enqueue(): failed to enqueue block {} "
+                            "(queue is full). Sleeping "
+                            "before trying one more time..."),
+                 block_id);
+    std::this_thread::sleep_for(timeout / 25);
+  }
+
+  SPDLOG_DEBUG(
+      FMT_STRING("SerializedBlockPQueue::try_enqueue(): failed to enqueue block {}: timed out!"),
+      block_id);
+  return false;
+}
+
+template <typename BlockID>
+inline auto SerializedBlockPQueue<BlockID>::dequeue_timed(std::chrono::milliseconds timeout)
+    -> Record {
+  const auto expiration = std::chrono::steady_clock::now() + timeout;
+  while (HICTK_LIKELY(std::chrono::steady_clock::now() < expiration)) {
+    {
+      [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+      auto result = dequeue_unsafe();
+      if (result.status != Record::Status::NOT_AVAILABLE) {
+        return result;
+      }
+    }
+    SPDLOG_DEBUG(
+        FMT_STRING("SerializedBlockPQueue::dequeue_timed(): queue is empty. Sleeping before trying "
+                   "one more time..."));
+    std::this_thread::sleep_for(timeout / 25);
+  }
+
+  SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_timed(): operation timed out"));
+  return {{}, "", Record::Status::TIMEOUT};
+}
+
+template <typename BlockID>
+inline void SerializedBlockPQueue<BlockID>::dequeue(std::vector<Record>& buffer) {
+  buffer.clear();
+  [[maybe_unused]] const auto lck = std::scoped_lock(_mtx);
+  const auto fill_rate = static_cast<double>(_buff.size()) / static_cast<double>(_capacity);
+  if (_block_ids.size() != _buff.size() && fill_rate < 0.5) {
+    // Queue is not full enough to be worth returning available items
+    SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue(): not bothering dequeuing blocks "
+                            "(queue is only {}% full)"),
+                 100.0 * fill_rate);
+    return;
+  }
+  dequeue_unsafe(buffer);
+}
+
+template <typename BlockID>
+inline auto SerializedBlockPQueue<BlockID>::dequeue_unsafe() noexcept -> Record {
+  if (HICTK_UNLIKELY(_block_ids.empty())) {
+    SPDLOG_DEBUG(
+        FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): caught attempt to fetch block from a "
+                   "closed queue"));
+    return {{}, "", Record::Status::QUEUE_IS_CLOSED};
+  }
+
+  const auto wanted_bid = _block_ids.back();
+  if (!_buff.empty()) {
+    assert(!_block_ids.empty());
+    auto& [bid, value] = *_buff.begin();
+    assert(bid > wanted_bid || bid == wanted_bid);
+    if (bid == wanted_bid) {
+      assert(!value.empty());
+      SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): returning block {}..."),
+                   bid);
+      Record record{bid, std::move(value), Record::Status::SUCCESS};
+      _buff.erase(_buff.begin());
+      _block_ids.pop_back();
+      return record;
+    }
+  }
+
+  SPDLOG_DEBUG(
+      FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): block {} has not yet been enqueued!"),
+      wanted_bid);
+  return {{}, "", Record::Status::NOT_AVAILABLE};
+}
+
+template <typename BlockID>
+inline void SerializedBlockPQueue<BlockID>::dequeue_unsafe(std::vector<Record>& buffer) {
+  buffer.clear();
+  while (true) {
+    auto record = dequeue_unsafe();
+    if (!record) {
+      SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): dequeued {} blocks"),
+                   buffer.size());
+      return;
+    }
+    buffer.emplace_back(std::move(record));
+  }
+}
+
+}  // namespace hictk::hic::internal

--- a/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
+++ b/src/libhictk/hic/include/hictk/hic/interaction_to_block_mapper.hpp
@@ -13,6 +13,7 @@
 #else
 #include <readerwriterqueue/readerwriterqueue.h>
 #endif
+#include <fmt/format.h>
 #include <zstd.h>
 
 #include <BS_thread_pool.hpp>
@@ -69,6 +70,7 @@ class HiCInteractionToBlockMapper {
     std::uint64_t bid;
 
     [[nodiscard]] bool operator<(const BlockID& other) const noexcept;
+    [[nodiscard]] bool operator>(const BlockID& other) const noexcept;
     [[nodiscard]] bool operator==(const BlockID& other) const noexcept;
   };
 
@@ -77,16 +79,18 @@ class HiCInteractionToBlockMapper {
     std::uint32_t size;
   };
 
+  using BlockIndexMap = phmap::btree_map<BlockID, std::vector<BlockIndex>>;
+
  private:
   std::filesystem::path _path{};
-  filestream::FileStream _fs{};
+  filestream::FileStream<> _fs{};
   std::shared_ptr<const BinTable> _bin_table{};
 
-  using BlockIndexMap = phmap::btree_map<BlockID, std::vector<BlockIndex>>;
-  using ChromosomeIndexMap =
+  using MatrixIndexMap =
       phmap::flat_hash_map<std::pair<Chromosome, Chromosome>, phmap::btree_set<BlockID>>;
+
   BlockIndexMap _block_index{};
-  ChromosomeIndexMap _chromosome_index{};
+  MatrixIndexMap _chromosome_index{};
 
   phmap::btree_map<BlockID, MatrixInteractionBlockFlat<float>> _blocks{};
   phmap::flat_hash_map<std::pair<Chromosome, Chromosome>, float> _pixel_sums{};
@@ -139,7 +143,7 @@ class HiCInteractionToBlockMapper {
                      std::uint32_t update_frequency = 10'000'000);
 
   [[nodiscard]] auto block_index() const noexcept -> const BlockIndexMap&;
-  [[nodiscard]] auto chromosome_index() const noexcept -> const ChromosomeIndexMap&;
+  [[nodiscard]] auto chromosome_index() const noexcept -> const MatrixIndexMap&;
   [[nodiscard]] auto merge_blocks(const BlockID& bid) -> MatrixInteractionBlock<float>;
   [[nodiscard]] auto merge_blocks(const BlockID& bid, BinaryBuffer& bbuffer, ZSTD_DCtx_s& zstd_dctx,
                                   std::string& compression_buffer, std::mutex& mtx)
@@ -220,5 +224,25 @@ struct std::hash<hictk::hic::internal::HiCInteractionToBlockMapper::BlockID> {
     return hictk::internal::hash_combine(0, bid.chrom1_id, bid.chrom2_id, bid.bid);
   }
 };
+
+namespace fmt {
+template <>
+struct formatter<hictk::hic::internal::HiCInteractionToBlockMapper::BlockID> {
+  constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+    if (ctx.begin() != ctx.end() && *ctx.begin() != '}') {
+      throw fmt::format_error("invalid format");
+    }
+
+    return ctx.end();
+  }
+
+  inline format_context::iterator format(
+      const hictk::hic::internal::HiCInteractionToBlockMapper::BlockID& bid,
+      format_context& ctx) const {
+    return fmt::format_to(ctx.out(), FMT_STRING("{}"), bid.bid);
+  }
+};
+
+}  // namespace fmt
 
 #include "./impl/interaction_to_block_mapper_impl.hpp"  // NOLINT

--- a/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
+++ b/src/libhictk/hic/include/hictk/hic/serialized_block_pqueue.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <parallel_hashmap/btree.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace hictk::hic::internal {
+
+template <typename BlockID>
+class SerializedBlockPQueue {
+  std::vector<BlockID> _block_ids{};
+  phmap::btree_map<BlockID, std::string> _buff{};
+  mutable std::mutex _mtx{};
+  std::size_t _capacity{256};
+  std::size_t _producers{1};
+
+ public:
+  struct Record {
+    enum class Status : std::uint_fast8_t { SUCCESS, TIMEOUT, NOT_AVAILABLE, QUEUE_IS_CLOSED };
+
+    BlockID bid{};
+    std::string serialized_block{};
+    Status status{Status::SUCCESS};
+
+    [[nodiscard]] explicit operator bool() const noexcept;
+  };
+
+  SerializedBlockPQueue() = default;
+  template <typename It>
+  SerializedBlockPQueue(It first_bid, It last_bid, std::size_t producers,
+                        std::size_t capacity_ = 0);
+
+  [[nodiscard]] std::size_t size() const;
+  [[nodiscard]] std::size_t capacity() const noexcept;
+
+  [[nodiscard]] bool try_enqueue(const BlockID& block_id, const std::string& serialized_block,
+                                 std::chrono::milliseconds timeout = std::chrono::seconds(1));
+  [[nodiscard]] auto dequeue_timed(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(50)) -> Record;
+  void dequeue(std::vector<Record>& buffer);
+
+ private:
+  [[nodiscard]] auto dequeue_unsafe() noexcept -> Record;
+  void dequeue_unsafe(std::vector<Record>& buffer);
+};
+
+}  // namespace hictk::hic::internal
+
+#include "./impl/serialized_block_pqueue_impl.hpp"

--- a/test/units/balancing/matrix_test.cpp
+++ b/test/units/balancing/matrix_test.cpp
@@ -532,7 +532,7 @@ const std::vector<ThinPixel<std::int32_t>> pixels{
     std::string buff{};
 
     SECTION("empty matrix") {
-      auto f = filestream::FileStream::create(tmpfile.string());
+      auto f = filestream::FileStream<>::create(tmpfile.string(), nullptr);
 
       SparseMatrix m1{};
       SparseMatrix m2{};
@@ -554,7 +554,7 @@ const std::vector<ThinPixel<std::int32_t>> pixels{
       m1.finalize();
 
       std::filesystem::remove(tmpfile);  // NOLINT
-      auto f = filestream::FileStream::create(tmpfile.string());
+      auto f = filestream::FileStream<>::create(tmpfile.string(), nullptr);
 
       SparseMatrix m2{};
       m1.serialize(f, buff, *zstd_cctx);

--- a/test/units/filestream/filestream_test.cpp
+++ b/test/units/filestream/filestream_test.cpp
@@ -6,11 +6,15 @@
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -26,7 +30,7 @@ const auto path_plaintext = (datadir / "data.txt").string();  // NOLINT(cert-err
 const auto path_binary = (datadir / "data.zip").string();     // NOLINT(cert-err58-cpp)
 const auto& path = path_plaintext;
 
-static std::string read_file(const std::string& path_) {
+[[maybe_unused]] static std::string read_file(const std::string& path_) {
   std::ifstream ifs(path_, std::ios::ate);
   REQUIRE(ifs);
   const auto size = ifs.tellg();
@@ -37,7 +41,8 @@ static std::string read_file(const std::string& path_) {
   return buff;
 }
 
-static std::vector<std::string> read_file_by_line(const std::string& path_, char delim = '\n') {
+[[maybe_unused]] static std::vector<std::string> read_file_by_line(const std::string& path_,
+                                                                   char delim = '\n') {
   std::ifstream ifs(path_);
   REQUIRE(ifs);
 
@@ -53,15 +58,15 @@ static std::vector<std::string> read_file_by_line(const std::string& path_, char
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream ctor", "[hic][filestream][short]") {
+TEST_CASE("FileStream ctor", "[filestream][short]") {
   SECTION("default") {
-    const FileStream s{};
+    const FileStream<> s{};
     CHECK(s.path().empty());
     CHECK(s.size() == 0);
   }
 
   SECTION("valid path (read)") {
-    const FileStream s(path_plaintext);
+    const FileStream<> s(path_plaintext, nullptr);
     CHECK(s.path() == path_plaintext);
     CHECK(s.size() == 502941);
     CHECK(!s.eof());
@@ -69,19 +74,19 @@ TEST_CASE("HiC: filestream ctor", "[hic][filestream][short]") {
 
   SECTION("valid path (write)") {
     const auto path1 = testdir() / "filestream_ctor_write.bin";
-    const auto s = FileStream::create(path1.string());
+    const auto s = FileStream<>::create(path1.string(), nullptr);
     CHECK(s.path() == path1);
     CHECK(s.size() == 0);
     CHECK(!s.eof());
   }
 
-  SECTION("invalid path") { CHECK_THROWS(FileStream("not-a-path")); }
+  SECTION("invalid path") { CHECK_THROWS(FileStream<>("not-a-path", nullptr)); }
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream seek", "[hic][filestream][short]") {
+TEST_CASE("FileStream seek", "[filestream][short]") {
   SECTION("read") {
-    FileStream s(path_plaintext);
+    FileStream<> s(path_plaintext, nullptr);
     SECTION("seek within chunk") {
       s.seekg(5);
       CHECK(s.tellg() == 5);
@@ -113,14 +118,14 @@ TEST_CASE("HiC: filestream seek", "[hic][filestream][short]") {
       CHECK_THROWS(s.seekg(1, std::ios::cur));
 
       s.seekg(0);
-      CHECK_THROWS(s.seekg(1, std::ios::end));
+      CHECK_THROWS(s.seekg(-1, std::ios::end));
       CHECK(s.tellg() == 0);
     }
   }
   SECTION("write") {
     const auto path1 = testdir() / "filestream_seek.bin";
-    std::filesystem::remove(path1);
-    auto s = FileStream::create(path1.string());
+    std::filesystem::remove(path1);  // NOLINT
+    auto s = FileStream<>::create(path1.string(), nullptr);
 
     SECTION("seek within chunk") {
       s.seekp(5);
@@ -156,12 +161,11 @@ TEST_CASE("HiC: filestream seek", "[hic][filestream][short]") {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream read", "[hic][filestream][short]") {
-  FileStream s(path_plaintext);
-
+TEST_CASE("FileStream read", "[filestream][short]") {
+  FileStream<> s(path_plaintext, nullptr);
   std::string buffer{"garbage"};
   const auto expected = read_file(path);
-  REQUIRE(s.size() == expected.size());
+  REQUIRE(s.size() == static_cast<std::streamsize>(expected.size()));
 
   SECTION("small read") {
     s.read(buffer, 10);
@@ -169,7 +173,7 @@ TEST_CASE("HiC: filestream read", "[hic][filestream][short]") {
   }
 
   SECTION("large read") {
-    s.read(buffer, s.size());
+    s.read(buffer, static_cast<std::size_t>(s.size()));
     CHECK(buffer == expected);
   }
 
@@ -179,16 +183,14 @@ TEST_CASE("HiC: filestream read", "[hic][filestream][short]") {
   }
 
   SECTION("seek and read") {
-    const auto offset = s.size() - 10;
-    s.seekg(std::int64_t(offset));
-    s.read(buffer, 10);
+    const auto offset = static_cast<std::size_t>(s.size() - 10);
+    s.seek_and_read(static_cast<std::int64_t>(offset), buffer, 10);
     CHECK(buffer == expected.substr(offset));
   }
 
   SECTION("seek and read out-of-bound") {
-    const auto offset = s.size() - 10;
-    s.seekg(std::int64_t(offset));
-    CHECK_THROWS(s.read(buffer, 11));
+    const auto offset = static_cast<std::streampos>(s.size() - 10);
+    CHECK_THROWS(s.seek_and_read(offset, buffer, 11));
   }
 
   SECTION("read within chunk") {
@@ -198,11 +200,66 @@ TEST_CASE("HiC: filestream read", "[hic][filestream][short]") {
     s.read(buffer, 5);
     CHECK(buffer == expected.substr(5, 5));
   }
+
+  SECTION("multi-threaded") {
+    s = FileStream<>(path_plaintext, std::make_shared<std::mutex>());
+
+    const std::streampos offset1 = 0;
+    const std::streampos offset2 = 5;
+
+    s.seekg(offset1);
+    const auto expected1 = s.read(10);
+    s.seekg(offset2);
+    const auto expected2 = s.read(10);
+
+    REQUIRE(expected1.size() == 10);
+    REQUIRE(expected2.size() == 10);
+
+    std::atomic<std::size_t> threads_started{};
+    std::mutex catch2_mtx{};
+
+    auto worker = [&](std::size_t id, std::streampos offset, std::string_view expected_) {
+      std::string buffer_;
+      std::size_t tests = 0;
+      std::size_t failures = 0;
+
+      threads_started++;
+      while (threads_started != 2);  // NOLINT
+
+      try {
+        const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        for (; std::chrono::steady_clock::now() < timepoint; ++tests) {
+          buffer_.clear();
+          const auto new_offset = s.seek_and_read(offset, buffer_, expected_.size()).second;
+          // NOLINTNEXTLINE(readability-implicit-bool-conversion)
+          failures += new_offset != offset + std::streamoff(expected_.size());
+
+          [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);
+          CHECK(new_offset == offset + std::streamoff(expected_.size()));
+        }
+
+        return std::make_pair(tests, failures);
+      } catch (const std::exception& e) {
+        throw std::runtime_error("Exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + "): " + e.what());
+      } catch (...) {
+        throw std::runtime_error("Unknown exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + ")");
+      }
+    };
+
+    auto w1 = std::async(std::launch::async, worker, 1, offset1, expected1);
+    auto w2 = std::async(std::launch::async, worker, 2, offset2, expected2);
+
+    const auto [tests1, fails1] = w1.get();
+    const auto [tests2, fails2] = w2.get();
+    printf("performed %zu reads (%zu failures)\n", tests1 + tests2, fails1 + fails2);  // NOLINT
+  }
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream read_append", "[hic][filestream][short]") {
-  FileStream s(path_plaintext);
+TEST_CASE("FileStream read_append", "[filestream][short]") {
+  FileStream<> s(path_plaintext, nullptr);
 
   std::string buffer;
   const auto expected = read_file(path);
@@ -219,7 +276,7 @@ TEST_CASE("HiC: filestream read_append", "[hic][filestream][short]") {
   }
 
   SECTION("large append") {
-    s.read_append(buffer, s.size());
+    s.read_append(buffer, static_cast<std::size_t>(s.size()));
     CHECK(buffer == expected);
   }
 
@@ -229,14 +286,14 @@ TEST_CASE("HiC: filestream read_append", "[hic][filestream][short]") {
   }
 
   SECTION("out-of-bound read") {
-    s.seekg(-1, std::ios::end);
+    s.seekg(1, std::ios::end);
     CHECK_THROWS(s.read_append(buffer, 10));
   }
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream getline", "[hic][filestream][short]") {
-  FileStream s(path_plaintext);
+TEST_CASE("FileStream getline", "[filestream][short]") {
+  FileStream<> s(path_plaintext, nullptr);
 
   std::string buffer;
   const auto expected = read_file_by_line(path);
@@ -249,12 +306,12 @@ TEST_CASE("HiC: filestream getline", "[hic][filestream][short]") {
   }
 
   SECTION("seek and getline") {
-    s.seekg(765);
-    CHECK(s.getline(buffer) == true);
+    auto status = s.seek_and_getline(765, buffer);
+    CHECK(std::get<0>(status) == true);
     CHECK(buffer == "ibes the overall architecture of HTTP,");
 
-    s.seekg(0);
-    CHECK(s.getline(buffer) == true);
+    status = s.seek_and_getline(0, buffer);
+    CHECK(std::get<0>(status) == true);
     CHECK(buffer == expected.at(0));
   }
 
@@ -275,12 +332,75 @@ TEST_CASE("HiC: filestream getline", "[hic][filestream][short]") {
     CHECK(s.getline(buffer, ':'));
     CHECK(buffer == " Ed.\nRequest for Comments");
   }
+
+  SECTION("multi-threaded") {
+    s = FileStream<>(path_plaintext, std::make_shared<std::mutex>());
+
+    const std::streampos offset1 = 25;
+    const std::streampos offset2 = 30;
+
+    s.seekg(offset1);
+    const auto expected1 = s.getline();
+    s.seekg(offset2);
+    const auto expected2 = s.getline();
+
+    REQUIRE(!expected1.empty());
+    REQUIRE(!expected2.empty());
+
+    std::atomic<std::size_t> threads_started{};
+    std::mutex catch2_mtx{};
+
+    auto worker = [&](std::size_t id, std::streampos offset, std::string_view expected_) {
+      std::string buffer_;
+      std::size_t tests = 0;
+      std::size_t failures = 0;
+
+      const auto offset_after_read_expected = offset + std::streamoff(expected_.size() + 1);
+
+      threads_started++;
+      while (threads_started != 2);  // NOLINT
+
+      try {
+        const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        for (; std::chrono::steady_clock::now() < timepoint; ++tests) {
+          buffer_.clear();
+          const auto status = s.seek_and_getline(offset, buffer_);
+          const auto delimiter_found = std::get<0>(status);
+          const auto offset_after_read = std::get<2>(status);
+
+          failures += static_cast<std::size_t>(offset_after_read != offset_after_read_expected ||
+                                               expected_ != buffer_);
+
+          [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);
+          CHECK(delimiter_found);
+          CHECK(offset_after_read == offset_after_read_expected);
+          CHECK(expected_ == buffer_);
+        }
+
+        return std::make_pair(tests, failures);
+      } catch (const std::exception& e) {
+        throw std::runtime_error("Exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + "): " + e.what());
+      } catch (...) {
+        throw std::runtime_error("Unknown exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + ")");
+      }
+    };
+
+    auto w1 = std::async(std::launch::async, worker, 1, offset1, expected1);
+    auto w2 = std::async(std::launch::async, worker, 2, offset2, expected2);
+
+    const auto [tests1, fails1] = w1.get();
+    const auto [tests2, fails2] = w2.get();
+    printf("performed %zu reads (%zu failures)\n", tests1 + tests2, fails1 + fails2);  // NOLINT
+  }
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream read binary", "[hic][filestream][short]") {
-  FileStream s(path_binary);
-  s.seekg(10);
+TEST_CASE("FileStream read binary", "[filestream][short]") {
+  FileStream<> s(path_binary, nullptr);
+  const std::streampos offset = 10;
+  s.seekg(offset);
 
   // Expected numbers were computed with Python code like the following:
   // for t in [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64,
@@ -291,23 +411,46 @@ TEST_CASE("HiC: filestream read binary", "[hic][filestream][short]") {
   HICTK_DISABLE_WARNING_USELESS_CAST
   SECTION("uint8") { CHECK(s.read<std::uint8_t>() == std::uint8_t(162)); }
   SECTION("uint16") { CHECK(s.read<std::uint16_t>() == std::uint16_t(42658)); }
-  SECTION("uint32") { CHECK(s.read<std::uint32_t>() == std::uint32_t(1433446050)); }
-  SECTION("uint64") { CHECK(s.read<std::uint64_t>() == std::uint64_t(18260117889181853346ULL)); }
+  SECTION("uint32") {
+    CHECK(s.read<std::uint32_t>() == std::uint32_t(1433446050));
+    CHECK(std::is_same_v<decltype(s.read_as_signed<std::uint32_t>()), std::int32_t>);
+    s.seekg(offset);
+    CHECK(s.read_as_signed<std::uint32_t>() == std::int32_t(1433446050));
+  }
+  SECTION("uint64") {
+    CHECK(s.read<std::uint64_t>() == std::uint64_t(18260117889181853346ULL));
+    CHECK(std::is_same_v<decltype(s.read_as_signed<std::uint64_t>()), std::int64_t>);
+    s.seekg(offset);
+    CHECK(s.read_as_signed<std::uint64_t>() == std::int64_t(-186626184527698270LL));
+  }
 
   SECTION("int8") { CHECK(s.read<std::int8_t>() == std::int8_t(-94)); }
   SECTION("int16") { CHECK(s.read<std::int16_t>() == std::int16_t(-22878)); }
-  SECTION("int32") { CHECK(s.read<std::int32_t>() == std::int32_t(1433446050)); }
-  SECTION("int64") { CHECK(s.read<std::int64_t>() == std::int64_t(-186626184527698270)); }
+  SECTION("int32") {
+    CHECK(s.read<std::int32_t>() == std::int32_t(1433446050));
+    CHECK(std::is_same_v<decltype(s.read_as_unsigned<std::int32_t>()), std::uint32_t>);
+    s.seekg(offset);
+    CHECK(s.read_as_unsigned<std::int32_t>() == std::uint32_t(1433446050));
+  }
+  SECTION("int64") {
+    CHECK(s.read<std::int64_t>() == std::int64_t(-186626184527698270));
+    CHECK(std::is_same_v<decltype(s.read_as_unsigned<std::int64_t>()), std::uint64_t>);
+    s.seekg(offset);
+    CHECK(s.read_as_unsigned<std::int64_t>() == std::uint64_t(18260117889181853346ULL));
+  }
 
   SECTION("float") { CHECK(s.read<float>() == 16537405000000.0F); }
-  SECTION("double") { CHECK(s.read<double>() == -1.2758357206942371e+296); }
+  SECTION("double") {
+    CHECK(s.read<double>() == -1.2758357206942371e+296);
+    s.seekg(offset);
+    CHECK(s.read_as_double<float>() == 16537404571648.0);
+  }
 
   SECTION("char") { CHECK(s.read<char>() == static_cast<char>(162)); }
   SECTION("unsigned char") { CHECK(s.read<unsigned char>() == static_cast<unsigned char>(162)); }
   HICTK_DISABLE_WARNING_POP
 
   SECTION("vector") {
-    s.seekg(0);
     constexpr std::array<std::int32_t, 32> expected{
         67324752,    20,          -1499332600, -126266000,  316472680,   -71892991,  720898,
         926220316,   758592304,   2020879920,  156521844,   1067451136,  1101095797, 2020959093,
@@ -315,7 +458,15 @@ TEST_CASE("HiC: filestream read binary", "[hic][filestream][short]") {
         -1957338045, 1449544581,  1142046551,  -518143477,  -1249957234, 831590659,  -732484307,
         1294996684,  -1436898904, 1231094186,  1614771469};
 
-    const auto buffer = s.read<std::int32_t>(expected.size());
+    s.seekg(0);
+    auto buffer = s.read_vector<std::int32_t>(expected.size());
+    REQUIRE(expected.size() == buffer.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+      CHECK(expected[i] == buffer[i]);
+    }
+
+    std::fill(buffer.begin(), buffer.end(), 0);
+    s.seek_and_read(0, buffer);
     REQUIRE(expected.size() == buffer.size());
     for (std::size_t i = 0; i < expected.size(); ++i) {
       CHECK(expected[i] == buffer[i]);
@@ -324,10 +475,10 @@ TEST_CASE("HiC: filestream read binary", "[hic][filestream][short]") {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream write", "[hic][filestream][short]") {
+TEST_CASE("FileStream write", "[filestream][short]") {
   const auto tmpfile = testdir() / "filestream_write.bin";
-  std::filesystem::remove(tmpfile);
-  auto s = FileStream::create(tmpfile.string());
+  std::filesystem::remove(tmpfile);  // NOLINT
+  auto s = FileStream<>::create(tmpfile.string(), nullptr);
 
   SECTION("small write") {
     constexpr std::string_view buffer{"test"};
@@ -338,7 +489,7 @@ TEST_CASE("HiC: filestream write", "[hic][filestream][short]") {
   SECTION("large write") {
     const auto buffer = read_file(path);
     s.write(buffer);
-    CHECK(s.size() == buffer.size());
+    CHECK(s.size() == static_cast<std::streamsize>(buffer.size()));
   }
 
   SECTION("no-op read") {
@@ -354,10 +505,71 @@ TEST_CASE("HiC: filestream write", "[hic][filestream][short]") {
     s.write(buffer);
     CHECK(s.size() == buffer.size() + offset);
   }
+  SECTION("multi-threaded") {
+    s.close();
+    std::filesystem::remove(tmpfile);  // NOLINT
+    s = FileStream<>::create(tmpfile.string(), std::make_shared<std::mutex>());
+
+    std::string_view msg1{"0123456789"};
+    std::string_view msg2{"abcdefghijklmnopqrstwxyz"};
+
+    const std::streampos offset1 = 0;
+    const std::streampos offset2 = offset1 + static_cast<std::streamoff>(msg1.size());
+
+    const std::streamsize expected_file_size = offset2 + static_cast<std::streamoff>(msg2.size());
+
+    REQUIRE(s.size() == 0);
+
+    std::atomic<std::size_t> threads_started{};
+    std::mutex catch2_mtx{};
+
+    auto worker = [&](std::size_t id, std::streampos offset, std::string_view message) {
+      std::size_t tests = 0;
+      std::size_t failures = 0;
+
+      threads_started++;
+      while (threads_started != 2);  // NOLINT
+
+      try {
+        const auto timepoint = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        for (; std::chrono::steady_clock::now() < timepoint; ++tests) {
+          const auto new_offset = s.seek_and_write(offset, message).second;
+          // NOLINTNEXTLINE(readability-implicit-bool-conversion)
+          failures += offset + static_cast<std::streamoff>(message.size()) != new_offset;
+
+          [[maybe_unused]] const auto lck = std::scoped_lock(catch2_mtx);
+          CHECK(offset + static_cast<std::streamoff>(message.size()) == new_offset);
+        }
+
+        return std::make_pair(tests, failures);
+      } catch (const std::exception& e) {
+        throw std::runtime_error("Exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + "): " + e.what());
+      } catch (...) {
+        throw std::runtime_error("Unknown exception caught in worker #" + std::to_string(id) +
+                                 " (iteration " + std::to_string(tests) + ")");
+      }
+    };
+
+    auto w1 = std::async(std::launch::async, worker, 1, offset1, msg1);
+    auto w2 = std::async(std::launch::async, worker, 2, offset2, msg2);
+
+    const auto [tests1, fails1] = w1.get();
+    const auto [tests2, fails2] = w2.get();
+    printf("performed %zu writes (%zu failures)\n", tests1 + tests2, fails1 + fails2);  // NOLINT
+
+    REQUIRE(s.size() == expected_file_size);
+
+    std::string buff{};
+    s.seek_and_read(offset1, buff, msg1.size());
+    CHECK(buff == msg1);
+    s.seek_and_read(offset2, buff, msg2.size());
+    CHECK(buff == msg2);
+  }
 }
 
 template <typename T>
-static void write_and_compare(FileStream& s, const T& data) {
+static void write_and_compare(FileStream<>& s, const T& data) {
   s.write(data);
   s.flush();
   REQUIRE(s.size() == sizeof(T));
@@ -365,10 +577,10 @@ static void write_and_compare(FileStream& s, const T& data) {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: filestream write binary", "[hic][filestream][short]") {
+TEST_CASE("FileStream write binary", "[filestream][short]") {
   const auto tmpfile = testdir() / "filestream_write_binary.bin";
-  std::filesystem::remove(tmpfile);
-  auto s = FileStream::create(tmpfile.string());
+  std::filesystem::remove(tmpfile);  // NOLINT
+  auto s = FileStream<>::create(tmpfile.string(), nullptr);
 
   HICTK_DISABLE_WARNING_PUSH
   HICTK_DISABLE_WARNING_USELESS_CAST
@@ -400,8 +612,8 @@ TEST_CASE("HiC: filestream write binary", "[hic][filestream][short]") {
 
     s.write(data);
     s.flush();
-    REQUIRE(s.size() == sizeof(std::int32_t) * data.size());
-    const auto buffer = s.read<std::int32_t>(data.size());
+    REQUIRE(s.size() == static_cast<std::streamsize>(sizeof(std::int32_t) * data.size()));
+    const auto buffer = s.read_vector<std::int32_t>(data.size());
     REQUIRE(data.size() == buffer.size());
     for (std::size_t i = 0; i < data.size(); ++i) {
       CHECK(data[i] == buffer[i]);
@@ -409,4 +621,27 @@ TEST_CASE("HiC: filestream write binary", "[hic][filestream][short]") {
   }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("FileStream resize", "[filestream][short]") {
+  const auto tmpfile = testdir() / "filestream_write.bin";
+  std::filesystem::remove(tmpfile);  // NOLINT
+  auto s = FileStream<>::create(tmpfile.string(), nullptr);
+
+  const std::string_view msg{"this is a relatively long string"};
+
+  s.write(msg);
+  CHECK(s.size() == conditional_static_cast<std::streamsize>(msg.size()));
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == s.size());
+
+  s.resize(5);
+  CHECK(s.size() == std::streamsize{5});
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == 5);
+
+  s.resize(100);
+  CHECK(s.size() == std::streamsize{100});
+  CHECK(s.tellg() == 0);
+  CHECK(s.tellp() == 5);
+}
 }  // namespace hictk::filestream::test

--- a/test/units/hic/file_writer_test.cpp
+++ b/test/units/hic/file_writer_test.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: MIT
 
+#ifdef SPDLOG_ACTIVE_LEVEL
+#undef SPDLOG_ACTIVE_LEVEL
+#endif
+
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+
 #include "hictk/hic/file_writer.hpp"
 
 #include <catch2/catch_test_macros.hpp>
@@ -10,6 +16,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 #include <filesystem>
+#include <random>
 #include <string>
 
 #include "hictk/chromosome.hpp"
@@ -90,14 +97,116 @@ TEST_CASE("HiC: HiCInteractionToBlockMapper", "[hic][v9][short]") {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-[[maybe_unused]] static void compare_weights(const balancing::Weights& expected,
-                                             const balancing::Weights& found) {
-  REQUIRE(expected.size() == found.size());
-  for (std::size_t i = 0; i < expected.size(); ++i) {
+TEST_CASE("HiC: SerializedBlockPQueue", "[hic][v9][short]") {
+  using PQueue = SerializedBlockPQueue<std::uint64_t>;
+  spdlog::set_level(spdlog::level::trace);
+  const std::size_t num_threads = 32;
+
+  std::vector<PQueue::Record> records(num_threads * 100);
+  std::vector<std::uint64_t> blk_ids(num_threads * 100);
+
+  std::random_device rd;
+  std::mt19937_64 rand_eng(rd());
+
+  std::uint64_t bid = 0;
+  for (std::size_t i = 0; i < records.size(); ++i) {
+    bid = std::uniform_int_distribution<std::uint64_t>{bid + 1, bid + 10}(rand_eng);
+    records[i] = {bid, std::to_string(i), PQueue::Record::Status::SUCCESS};
+    blk_ids[i] = bid;
+  }
+
+  PQueue queue(blk_ids.begin(), blk_ids.end(), num_threads - 1);
+
+  REQUIRE(queue.size() == 0);
+  REQUIRE(queue.capacity() > 0);
+
+  std::atomic<std::size_t> i{};
+  std::atomic<std::size_t> threads_started{};
+
+  BS::thread_pool tpool(conditional_static_cast<BS::concurrency_t>(num_threads));
+
+  auto producer = [&]() {
+    std::random_device rd_;
+    std::mt19937_64 rand_eng_(rd_());
+
+    ++threads_started;
+    while (threads_started != num_threads);  // NOLINT
+
+    while (true) {
+      const auto idx = i++;
+      if (idx >= records.size()) {
+        return;
+      }
+
+      // Simulate time required for block compression
+      const std::chrono::milliseconds sleep_time{
+          std::uniform_int_distribution<std::int32_t>{25, 50}(rand_eng_)};
+      std::this_thread::sleep_for(sleep_time);
+
+      const auto& record = records[idx];
+      while (!queue.try_enqueue(record.bid, record.serialized_block));  // NOLINT
+    }
+  };
+
+  std::vector<std::future<void>> producers(num_threads - 1);
+  for (auto& prod : producers) {
+    prod = tpool.submit_task(producer);
+  }
+
+  auto consumer = tpool.submit_task([&]() {
+    std::vector<PQueue::Record> output;
+    ++threads_started;
+    while (true) {
+      auto record = queue.dequeue_timed();
+      if (record.status == PQueue::Record::Status::TIMEOUT) {
+        continue;
+      }
+      if (record.status == PQueue::Record::Status::QUEUE_IS_CLOSED) {
+        return output;
+      }
+      assert(!!record);
+      output.emplace_back(std::move(record));
+    }
+  });
+
+  for (auto& prod : producers) {
+    prod.get();
+  }
+  const auto output = consumer.get();
+
+  REQUIRE(output.size() == records.size());
+  REQUIRE(i >= records.size());
+  CHECK(queue.dequeue_timed().status == PQueue::Record::Status::QUEUE_IS_CLOSED);
+
+  for (std::size_t j = 0; j < records.size(); ++j) {
+    CHECK(output[j].bid == records[j].bid);
+  }
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void compare_weights(const hictk::balancing::Weights& weights_,
+                            const hictk::balancing::Weights& expected_, double atol = 1.0e-5,
+                            double rtol = 1.0e-5) {
+  REQUIRE(weights_.size() == expected_.size());
+
+  const auto weights = weights_(hictk::balancing::Weights::Type::DIVISIVE);
+  const auto expected = expected_(hictk::balancing::Weights::Type::DIVISIVE);
+
+  for (std::size_t i = 0; i < weights.size(); ++i) {
     if (std::isnan(expected[i])) {
-      CHECK(std::isnan(found[i]));
+      CHECK(std::isnan(weights[i]));
     } else {
-      CHECK(expected[i] == found[i]);
+      // Basically we don't care about the relative error when the weights are very small, as this
+      // will not lead to significant differences when balancing interactions
+      if (std::isnan(weights[i])) {
+        [[maybe_unused]] const volatile int foo{};
+      }
+      const auto delta = std::abs(weights[i] - expected[i]);
+      if (delta > atol) {
+        CHECK_THAT(weights[i], Catch::Matchers::WithinRel(expected[i], rtol));
+      } else {
+        CHECK_THAT(weights[i], Catch::Matchers::WithinAbs(expected[i], atol));
+      }
     }
   }
 }
@@ -170,32 +279,52 @@ TEST_CASE("HiC: HiCInteractionToBlockMapper", "[hic][v9][short]") {
   }
 }
 
+[[nodiscard]] static std::vector<double> generate_random_weights(std::uint32_t chrom_size,
+                                                                 std::uint32_t resolution,
+                                                                 bool fill_with_nans) {
+  std::vector<double> buff((chrom_size + resolution - 1) / resolution);
+  if (fill_with_nans) {
+    std::fill(buff.begin(), buff.end(), std::numeric_limits<double>::quiet_NaN());
+    return buff;
+  }
+  std::random_device rd{};
+  std::mt19937_64 rand_eng{rd()};
+
+  std::generate(buff.begin(), buff.end(),
+                [&]() { return std::uniform_real_distribution<double>{0, 1}(rand_eng); });
+
+  return buff;
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-TEST_CASE("HiC: HiCFileWriter", "[hic][v9][long]") {
+TEST_CASE("HiC: HiCFileWriter (creation)", "[hic][v9][long]") {
   const auto path1 = (datadir / "4DNFIZ1ZVXC8.hic9").string();
   const auto path2 = (testdir() / "hic_writer_001.hic").string();
   const auto path3 = (testdir() / "hic_writer_002.hic").string();
-  const auto path4 = (testdir() / "hic_writer_003.hic").string();
 
-  SECTION("create file (st)") {
-    const std::vector<std::uint32_t> resolutions{250'000, 500'000, 2'500'000};
-    hic_file_writer_create_file_test(path1, path2, resolutions, 1, false);
-  }
+  spdlog::set_level(spdlog::level::trace);
+
   SECTION("create file (mt)") {
     const std::vector<std::uint32_t> resolutions{25'000, 1'000'000, 2'500'000};
-    hic_file_writer_create_file_test(path1, path2, resolutions, 3, true);
+    hic_file_writer_create_file_test(path1, path2, resolutions, 16, true);
   }
 
   SECTION("regression PR 180") {
     // Ensure we can create .hic files having bin tables with 1 bin per chromosome
     // See https://github.com/paulsengroup/hictk/pull/180
     const hictk::Reference chromosomes{{0, "chr1", 10}};
-    HiCFileWriter w(path4, chromosomes, {100});
+    HiCFileWriter w(path3, chromosomes, {100});
 
     const std::vector<Pixel<float>> pixels{Pixel<float>{w.bins(100), 0, 0, 1.0F}};
     w.add_pixels(100, pixels.begin(), pixels.end());
     w.serialize();  // Before PR 180, this used to throw
   }
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("HiC: HiCFileWriter (add weights)", "[hic][v9][long]") {
+  const auto path1 = (datadir / "4DNFIZ1ZVXC8.hic9").string();
+  const auto path2 = (testdir() / "hic_writer_004.hic").string();
 
   SECTION("add weights") {
     const std::uint32_t resolution = 500'000;
@@ -203,7 +332,7 @@ TEST_CASE("HiC: HiCFileWriter", "[hic][v9][long]") {
 
     {
       // init file
-      HiCFileWriter w(path3, hf1.chromosomes(), {hf1.resolution()}, "dm6");
+      HiCFileWriter w(path2, hf1.chromosomes(), {hf1.resolution()}, "dm6");
       const auto sel = hf1.fetch();
       w.add_pixels(resolution, sel.begin<float>(), sel.end<float>());
       w.serialize();
@@ -211,7 +340,7 @@ TEST_CASE("HiC: HiCFileWriter", "[hic][v9][long]") {
 
     // add normalization weights
     {
-      HiCFileWriter w(path3);
+      HiCFileWriter w(path2);
       for (const auto& chrom : w.chromosomes()) {
         if (chrom.is_all()) {
           continue;
@@ -234,7 +363,7 @@ TEST_CASE("HiC: HiCFileWriter", "[hic][v9][long]") {
     }
 
     // compare
-    const hic::File hf2(path3, resolution);
+    const hic::File hf2(path2, resolution);
 
     const auto avail_norms = hf2.avail_normalizations();
     REQUIRE(avail_norms.size() == 1);
@@ -245,11 +374,72 @@ TEST_CASE("HiC: HiCFileWriter", "[hic][v9][long]") {
                                    hf2.fetch(balancing::Method::SCALE()).read_all<float>());
 
     const hic::File hf3(path1, resolution, MatrixType::expected);
-    const hic::File hf4(path3, resolution, MatrixType::expected);
+    const hic::File hf4(path2, resolution, MatrixType::expected);
 
     compare_weights(hf3.normalization("SCALE"), hf4.normalization("SCALE"));
     hic_file_writer_compare_pixels(hf3.fetch(balancing::Method::SCALE()).read_all<float>(),
                                    hf4.fetch(balancing::Method::SCALE()).read_all<float>());
+  }
+
+  SECTION("overwrite weights") {
+    const std::uint32_t resolution = 500'000;
+
+    {
+      // init file
+      const hic::File hf(path1, resolution);
+      std::filesystem::remove(path2);  // NOLINT
+      HiCFileWriter w(path2, hf.chromosomes(), {hf.resolution()}, "dm6");
+      const auto sel = hf.fetch();
+      w.add_pixels(resolution, sel.begin<float>(), sel.end<float>());
+      w.serialize();
+    }
+
+    // add normalization weights
+    std::vector<double> weights{};
+    {
+      const hic::File hf(path1, resolution);
+      HiCFileWriter w(path2);
+      for (const auto& chrom : w.chromosomes()) {
+        if (chrom.is_all()) {
+          continue;
+        }
+        const auto buff =
+            generate_random_weights(chrom.size(), resolution, hf.fetch(chrom.name()).empty());
+        weights.insert(weights.end(), buff.begin(), buff.end());
+        w.add_norm_vector("FOO", chrom, "BP", resolution,
+                          balancing::Weights{buff, balancing::Weights::Type::DIVISIVE}, false);
+      }
+      w.write_norm_vectors_and_norm_expected_values();
+    }
+    // compare weights
+    {
+      const hic::File hf(path2, resolution);
+      compare_weights(hf.normalization("FOO"),
+                      balancing::Weights{weights, balancing::Weights::Type::DIVISIVE});
+    }
+
+    // overwrite weights
+    {
+      weights.clear();
+      const hic::File hf(path1, resolution);
+      HiCFileWriter w(path2);
+      for (const auto& chrom : w.chromosomes()) {
+        if (chrom.is_all()) {
+          continue;
+        }
+        const auto buff =
+            generate_random_weights(chrom.size(), resolution, hf.fetch(chrom.name()).empty());
+        weights.insert(weights.end(), buff.begin(), buff.end());
+        w.add_norm_vector("FOO", chrom, "BP", resolution,
+                          balancing::Weights{buff, balancing::Weights::Type::DIVISIVE}, true);
+      }
+      w.write_norm_vectors_and_norm_expected_values();
+    }
+
+    // compare weights
+    const hic::File hf(path2, resolution);
+    compare_weights(hf.normalization("FOO"),
+                    balancing::Weights{weights, balancing::Weights::Type::DIVISIVE});
   }
 }
 


### PR DESCRIPTION
This PR introduces three main changes:

- updating the FileStream class to expose several member functions to perform atomic reads and writes to binary files
- updating HiCFileWriter to take advantage of the new FileStream functionality
- optimize serialization of .hic files (the optimizations are especially noticeable when writing .hic files using a low number of threads)

This was done with the aim of making it harder to misuse FileStream objects in concurrent applications (e.g. when creating .hic files using `HiCFileWriter`).