### PR TITLE
Fix to fuzzer suite

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks: >
   -boost-*,
   -bugprone-easily-swappable-parameters,
   -clang-analyzer-optin.core.EnumCastOutOfRange,
-  -clang-analyzer-unix.BlockInCriticalSection,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,

--- a/.github/workflows/fuzzy-testing.yml
+++ b/.github/workflows/fuzzy-testing.yml
@@ -112,12 +112,6 @@ jobs:
           - {
               dataset: "4DNFIYECESRC",
               format: "hic9",
-              normalization: "SCALE",
-              bin-type: "fixed",
-            }
-          - {
-              dataset: "4DNFIYECESRC",
-              format: "hic9",
               normalization: "VC",
               bin-type: "fixed",
             }

--- a/src/libhictk/balancing/include/hictk/balancing/weights.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/weights.hpp
@@ -33,7 +33,7 @@ class Weights {
   using WeightVectPtr = std::shared_ptr<WeightVect>;
 
   std::variant<ConstWeight, WeightVectPtr> _weights{ConstWeight{}};
-  Type _type{};
+  Type _type{Type::UNKNOWN};
 
  public:
   Weights() = default;

--- a/src/libhictk/hic/include/hictk/hic/impl/file_reader_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_reader_impl.hpp
@@ -450,7 +450,7 @@ inline void HiCFileReader::read_footer_norm(const Chromosome &chrom1, const Chro
     *weights1 = default_initialize_weight_vector(chrom1, wanted_norm, wanted_resolution);
   }
   if (weights2->empty()) {
-    *weights2 = default_initialize_weight_vector(chrom1, wanted_norm, wanted_resolution);
+    *weights2 = default_initialize_weight_vector(chrom2, wanted_norm, wanted_resolution);
   }
 }
 

--- a/test/fuzzer/README.md
+++ b/test/fuzzer/README.md
@@ -1,0 +1,163 @@
+<!--
+Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+
+SPDX-License-Identifier: MIT
+-->
+
+# hictk_fuzzer
+
+The instructions assume `hictk_fuzzer` is being built and run on a Linux machine.
+The fuzzer should be capable of running on other OS as well, but some of the steps may require some tweaking.
+
+Dependencies are installed using micromamba, but using PIP and/or your system package manager will do just fine.
+
+## Installing build and runtime dependencies
+
+```bash
+micromamba create -c conda-forge -c bioconda -f scripts/environment.yml
+
+# If you don't have a modern C++ compiler toolchain (e.g. GCC8+, Clang 8+, or Apple-clang 11+), you will need to install one.
+# Ideally, you should do this with your system package manager.
+# If that's not an option, you can try
+# micromamba install -c conda-forge -n hictk_fuzzer c-compiler cxx-compiler
+```
+
+## Building the fuzzer
+
+```bash
+micromamba activate hictk_fuzzer
+
+conan install conanfile.py                  \
+   --build='missing'                        \
+   -s build_type=Release                    \
+   -s compiler.libcxx=libstdc++11           \
+   -s compiler.cppstd=17                    \
+   --output-folder conan-env
+
+cmake -DCMAKE_BUILD_TYPE=Release           \
+      -DCMAKE_PREFIX_PATH="$PWD/conan-env" \
+      -DENABLE_DEVELOPER_MODE=ON           \
+      -DOPT_ENABLE_CLANG_TIDY=OFF          \
+      -DOPT_ENABLE_CPPCHECK=OFF            \
+      -DHICTK_ENABLE_TESTING=ON            \
+      -DHICTK_ENABLE_FUZZY_TESTING=ON      \
+      -DHICTK_BUILD_EXAMPLES=OFF           \
+      -DHICTK_DOWNLOAD_TEST_DATASET=OFF    \
+      -S ../../                            \
+      -B build
+
+cmake --build build -j $(nproc) -t hictk_fuzzer
+
+build/test/fuzzer/src/hictk_fuzzer --help
+```
+
+## Running the fuzzer
+
+Running the fuzzer requires a pair of matched files (see later steps).
+The reference file should always be a .\[m]cool file.
+The test matrix can be in any format supported by hictk.
+
+Furthermore, the fuzzer depends on Cooler
+
+### Installing runtime dependencies
+
+### Fuzzing hictk
+
+```bash
+micromamba activate hictk_fuzzer
+
+build/test/fuzzer/src/hictk_fuzzer fuzz \
+  --resolution 50000 \
+  --nproc $(nproc) \
+  --format df \
+  test.hic \
+  reference.cool
+```
+
+## Generating matched datasets from scratch
+
+**IMPORTANT!!** This is usually a slow and demanding process (both in terms of storage, time, and memory).
+
+### Downloading the requirements
+
+Generating matched datasets from scratch requires 4 input files:
+
+- A file with the reference genome in `.chrom.sizes` format (e.g. [hg38.chrom.sizes](https://hgdownload.cse.ucsc.edu/goldenpath/hg38/bigZips/hg38.chrom.sizes))
+- A file with interactions in `.pairs` format (e.g. [4DNFIYECESRC.pairs.gz](https://data.4dnucleome.org/files-processed/4DNFIYECESRC/#details))
+- HiCTools' .jar file: [v3.30.00](https://github.com/aidenlab/HiCTools/releases/tag/v3.30.00)
+- JuicerTools' .jar file: [v2.20.00](https://github.com/aidenlab/Juicebox/releases/tag/v2.20.00)
+
+### Generating matched datasets with fixed bin width
+
+```bash
+micromamba activate hictk_fuzzer
+
+# Sort/filter .chrom.sizes file
+
+grep '^chr[0-9XY]\+[[:space:]]' hg38.chrom.sizes |
+  sort -k1,1V > hg38.filtered.chrom.sizes
+
+# Depending on the size of the pairs file and the requested resolutions/normalizations this step could take several days
+scripts/create_datasets_for_fuzzer.py \
+  4DNFIYECESRC.pairs.gz \
+  4DNFIYECESRC \
+  --chrom-sizes hg38.filtered.chrom.sizes \
+  --juicer-tools-jar juicer_tools.2.20.00.jar \
+  --hic-tools-jar hic_tools.3.30.00.jar \
+  --tmpdir ./tmp/ \
+  --nproc $(nproc) \
+  -Xmx 500G \
+  --resolutions     1000 \
+                    2000 \
+                    5000 \
+                   10000 \
+                   25000 \
+                   50000 \
+                  100000 \
+                  250000 \
+                  500000 \
+                 1000000 \
+                 2500000 \
+                 5000000 \
+                10000000
+```
+
+### Generating marched datasets with variable bin width
+
+```bash
+micromamba activate hictk_fuzzer
+
+# Sort/filter .chrom.sizes file
+
+grep '^chr[0-9XY]\+[[:space:]]' hg38.chrom.sizes |
+  sort -k1,1V > hg38.filtered.chrom.sizes
+
+scripts/create_variable_bins_cooler_for_fuzzer.py \
+  4DNFIYECESRC.pairs.gz \
+  4DNFIYECESRC \
+  --bin-size-avg 100000 \
+  --bin-size-std 50000 \
+  --chrom-sizes hg38.filtered.chrom.sizes \
+  --tmpdir ./tmp/ \
+  --nproc $(nproc)
+```
+
+## Downloading matched datasets used by hictk's CI
+
+Datasets used by hictk's CI are hosted on Zenodo at the following DOIs:
+
+- [10.5281/zenodo.13754754](https://doi.org/10.5281/zenodo.13754754) - .cool datasets
+- [10.5281/zenodo.13754785](https://doi.org/10.5281/zenodo.13754785) - .hic v8
+- [10.5281/zenodo.13754807](https://doi.org/10.5281/zenodo.13754807) - .hic v9 datasets
+
+Downloading datasets can be automated using `scripts/download_test_datasets.py`
+
+```bash
+scripts/download_test_datasets.py \
+  test_files.json \
+  . \
+  --format cool hic8 hic9 \
+  --resolution 50000 \
+  --dataset 4DNFIYECESRC \
+  --nproc 3
+```

--- a/test/fuzzer/environment.yml
+++ b/test/fuzzer/environment.yml
@@ -8,10 +8,7 @@ dependencies:
   - cmake>=3.25
   - conan>=2.0.5
   - cooler>=0.10
-  # - hictkpy>=0.0.6
+  - hic2cool>=1
   - numpy<2
   - openjdk>=11
-  - packaging
   - pandas
-  - pip:
-      - git+https://github.com/paulsengroup/hictkpy.git@c74de01e7c6b7d6780a667894d590fdeb1cbf00d

--- a/test/fuzzer/environment.yml
+++ b/test/fuzzer/environment.yml
@@ -1,0 +1,17 @@
+# Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+# SPDX-License-Identifier: MIT
+
+name: hictk_fuzzer
+
+dependencies:
+  - python>=3.9
+  - cmake>=3.25
+  - conan>=2.0.5
+  - cooler>=0.10
+  # - hictkpy>=0.0.6
+  - numpy<2
+  - openjdk>=11
+  - packaging
+  - pandas
+  - pip:
+      - git+https://github.com/paulsengroup/hictkpy.git@c74de01e7c6b7d6780a667894d590fdeb1cbf00d

--- a/test/fuzzer/scripts/create_datasets_for_fuzzer.py
+++ b/test/fuzzer/scripts/create_datasets_for_fuzzer.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-import contextlib
 import gzip
 import logging
 import multiprocessing as mp
@@ -17,12 +16,13 @@ import subprocess as sp
 import sys
 import tempfile
 import time
-import warnings
 from concurrent.futures import ProcessPoolExecutor as Pool
 from typing import Dict, List, Tuple, Union
 
 import cooler
-import hic2cool
+import h5py
+import hictkpy
+import packaging
 import pandas as pd
 
 
@@ -145,6 +145,13 @@ def make_cli() -> argparse.ArgumentParser:
     )
 
     return cli
+
+
+def validate_hictkpy_version():
+    if packaging.Version(hictkpy.__version__) < packaging.Version("0.0.6"):
+        raise ImportError(
+            f"The installed version of hictkpy is too old ({hictkpy.__version__}). Please install hictkpy v0.0.6 or newer."
+        )
 
 
 def setup_logger(level):
@@ -515,14 +522,12 @@ def copy_hic_norms(
     logging.info(f"copying weights from {path_to_hic} to {path_to_cooler}...")
 
     t0 = time.time()
-    with contextlib.redirect_stdout(None), warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        hic2cool.hic2cool_extractnorms(str(path_to_hic), str(path_to_cooler), silent=True)
-
-    columns = cooler.Cooler(str(path_to_cooler)).bins().columns.tolist()
-    for norm in normalization_methods:
-        if norm not in columns:
-            raise RuntimeError(f'failed to copy "{norm}" normalization to Cooler file "{path_to_cooler}"')
+    hf = hictkpy.File(str(path_to_hic), hictkpy.File(str(path_to_cooler)).resolution())
+    with h5py.File(path_to_cooler, "a") as h5:
+        for norm in normalization_methods:
+            h5_path = f"/bins/{norm}"
+            h5.create_dataset(h5_path, data=hf.weights(norm, divisive=True), compression="gzip")
+            h5[h5_path].attr["divisive_weights"] = True
     t1 = time.time()
 
     logging.info(f"DONE! Copying weights from {path_to_hic} to {path_to_cooler}. Copying took {t1 - t0}s.")
@@ -531,6 +536,8 @@ def copy_hic_norms(
 def main():
     args = vars(make_cli().parse_args())
     setup_logger(args["verbosity"])
+
+    validate_hictkpy_version()
 
     out_prefix = args["output-prefix"]
     pairs = args["pairs"]

--- a/test/fuzzer/scripts/create_datasets_for_fuzzer.py
+++ b/test/fuzzer/scripts/create_datasets_for_fuzzer.py
@@ -22,7 +22,6 @@ from typing import Dict, List, Tuple, Union
 import cooler
 import h5py
 import hictkpy
-import packaging
 import pandas as pd
 
 
@@ -148,7 +147,9 @@ def make_cli() -> argparse.ArgumentParser:
 
 
 def validate_hictkpy_version():
-    if packaging.Version(hictkpy.__version__) < packaging.Version("0.0.6"):
+    from packaging.version import Version
+
+    if Version(hictkpy.__version__) <= Version("0.0.5"):
         raise ImportError(
             f"The installed version of hictkpy is too old ({hictkpy.__version__}). Please install hictkpy v0.0.6 or newer."
         )
@@ -527,7 +528,7 @@ def copy_hic_norms(
         for norm in normalization_methods:
             h5_path = f"/bins/{norm}"
             h5.create_dataset(h5_path, data=hf.weights(norm, divisive=True), compression="gzip")
-            h5[h5_path].attr["divisive_weights"] = True
+            h5[h5_path].attrs["divisive_weights"] = True
     t1 = time.time()
 
     logging.info(f"DONE! Copying weights from {path_to_hic} to {path_to_cooler}. Copying took {t1 - t0}s.")
@@ -550,7 +551,7 @@ def main():
     force = args["force"]
 
     with (
-        tempfile.TemporaryDirectory(prefix=str(args["tmpdir"] / "hictk-")) as tmpdir,
+        tempfile.TemporaryDirectory(dir=str(args["tmpdir"]), prefix="hictk-") as tmpdir,
         Pool(max_workers=nproc, initializer=setup_logger, initargs=(args["verbosity"],)) as pool,
     ):
 

--- a/test/fuzzer/scripts/download_test_datasets.py
+++ b/test/fuzzer/scripts/download_test_datasets.py
@@ -7,7 +7,6 @@
 
 import argparse
 import hashlib
-import itertools
 import json
 import logging
 import multiprocessing as mp

--- a/test/fuzzer/src/cli.cpp
+++ b/test/fuzzer/src/cli.cpp
@@ -132,6 +132,9 @@ static void add_common_args(CLI::App& sc, Config& c) {
               "Ignored when --format is not df.")
       ->capture_default_str();
   sc.add_option("--seed", c.seed, "Seed used for PRNG.")->capture_default_str();
+  sc.add_option("-v,--verbosity", c.verbosity, "Set verbosity of output to the console.")
+      ->check(CLI::Range(1, 4))
+      ->capture_default_str();
 }
 
 void Cli::make_fuzz_subcommand() {
@@ -286,7 +289,12 @@ void Cli::transform_args_fuzz_subcommand() {
   }
 }
 
-void Cli::transform_args_launch_worker_subcommand() {}
+void Cli::transform_args_launch_worker_subcommand() {
+  // in spdlog, high numbers correspond to low log levels
+  assert(_config.verbosity > 0 &&
+         _config.verbosity < 5);  // NOLINTNEXTLINE(*-narrowing-conversions)
+  _config.verbosity = static_cast<std::int16_t>(spdlog::level::critical) - _config.verbosity;
+}
 
 void Cli::transform_args() {
   using sc = subcommand;

--- a/test/fuzzer/src/fuzzer_scheduler.cpp
+++ b/test/fuzzer/src/fuzzer_scheduler.cpp
@@ -100,6 +100,7 @@ namespace hictk::fuzzer {
 }
 
 int fuzz_subcommand(const Config& c) {
+  assert(c.task_id == 0);
   [[maybe_unused]] const pybind11::scoped_interpreter guard{};
   try {
     SPDLOG_INFO(FMT_STRING("[executor] cooler version: {}"), cooler::version());

--- a/test/fuzzer/src/fuzzer_scheduler.cpp
+++ b/test/fuzzer/src/fuzzer_scheduler.cpp
@@ -43,7 +43,10 @@ namespace hictk::fuzzer {
                                 "--normalization",
                                 c.normalization,
                                 "--seed",
-                                fmt::to_string(seed)};
+                                fmt::to_string(seed),
+                                "--verbosity",
+                                fmt::to_string(c.verbosity)};
+
   if (c.resolution != 0) {
     args.emplace_back("--resolution");
     args.emplace_back(fmt::to_string(c.resolution));

--- a/test/fuzzer/src/fuzzer_scheduler.cpp
+++ b/test/fuzzer/src/fuzzer_scheduler.cpp
@@ -117,10 +117,10 @@ int fuzz_subcommand(const Config& c) {
     for (std::size_t i = 0; i < seeds.size(); ++i) {
       futures[i] = tpool.submit_task([&, id = i + 1, seed = seeds[i]]() {
         try {
-          // NONLINTBEGIN(clang-analyzer-unix.BlockInCriticalSection)
+          // NOLINTBEGIN(clang-analyzer-unix.BlockInCriticalSection)
           auto proc = spawn_worker_process(c, id, seed, ctx, ctx_mtx);
           return proc.wait();
-          // NONLINTEND(clang-analyzer-unix.BlockInCriticalSection)
+          // NOLINTEND(clang-analyzer-unix.BlockInCriticalSection)
         } catch (const std::exception& e) {
           SPDLOG_ERROR(FMT_STRING("[{}] error occurred in worker process: {}"), id, e.what());
           return 1;

--- a/test/fuzzer/src/fuzzer_worker.cpp
+++ b/test/fuzzer/src/fuzzer_worker.cpp
@@ -318,6 +318,11 @@ static void print_report(std::uint16_t task_id, std::size_t num_tests, std::size
           const auto range1 = q1.to_string();
           const auto range2 = q2.to_string();
 
+          SPDLOG_DEBUG(
+              FMT_STRING(
+                  "[{}] running test #{} (range1=\"{}\"; range2=\"{}\"; normalization=\"{}\")..."),
+              c.task_id, num_tests, range1, range2, c.normalization);
+
           fetch_pixels(tgt.chromosomes(), ref, range1, range2, c.normalization, expected);
           fetch_pixels(tgt, range1, range2, c.normalization, found);
 
@@ -345,6 +350,10 @@ static void print_report(std::uint16_t task_id, std::size_t num_tests, std::size
         generate_query_2d(chroms, rand_eng, chrom_sampler, c.query_length_avg, c.query_length_std);
     const auto range1 = q1.to_string();
     const auto range2 = q2.to_string();
+
+    SPDLOG_DEBUG(
+        FMT_STRING("[{}] running test #{} (range1=\"{}\"; range2=\"{}\"; normalization=\"{}\")..."),
+        c.task_id, num_tests, range1, range2, c.normalization);
 
     const auto expected_var = fetch_pixels_dense(ref, range1, range2, c.normalization);
     const auto found_var = fetch_pixels_dense(tgt, range1, range2, c.normalization);
@@ -377,6 +386,10 @@ static void print_report(std::uint16_t task_id, std::size_t num_tests, std::size
         generate_query_2d(chroms, rand_eng, chrom_sampler, c.query_length_avg, c.query_length_std);
     const auto range1 = q1.to_string();
     const auto range2 = q2.to_string();
+
+    SPDLOG_DEBUG(
+        FMT_STRING("[{}] running test #{} (range1=\"{}\"; range2=\"{}\"; normalization=\"{}\")..."),
+        c.task_id, num_tests, range1, range2, c.normalization);
 
     const auto expected_var = fetch_pixels_sparse(ref, range1, range2, c.normalization);
     const auto found_var = fetch_pixels_sparse(tgt, range1, range2, c.normalization);

--- a/test/fuzzer/src/fuzzer_worker.cpp
+++ b/test/fuzzer/src/fuzzer_worker.cpp
@@ -409,6 +409,7 @@ static void print_report(std::uint16_t task_id, std::size_t num_tests, std::size
 }
 
 int launch_worker_subcommand(const Config& c) {
+  assert(c.task_id > 0);
   [[maybe_unused]] const pybind11::scoped_interpreter guard{};
 
   try {

--- a/test/fuzzer/src/fuzzer_worker.cpp
+++ b/test/fuzzer/src/fuzzer_worker.cpp
@@ -405,7 +405,7 @@ int launch_worker_subcommand(const Config& c) {
     std::mt19937_64 rand_eng{*c.seed};
     // NOLINTEND(bugprone-unchecked-optional-access)
 
-    const hictk::File tgt(c.reference_uri, c.resolution);
+    const hictk::File tgt(c.test_uri, c.resolution);
     cooler::Cooler ref(
         hictk::cooler::utils::is_multires_file(c.reference_uri.string())
             ? fmt::format(FMT_STRING("{}::/resolutions/{}"), c.reference_uri.string(), c.resolution)

--- a/test/fuzzer/src/include/hictk/fuzzer/config.hpp
+++ b/test/fuzzer/src/include/hictk/fuzzer/config.hpp
@@ -14,7 +14,7 @@ namespace hictk::fuzzer {
 
 // NOLINTBEGIN(*-avoid-magic-numbers)
 struct Config {
-  std::uint16_t task_id{};
+  std::uint16_t task_id{0};
   std::filesystem::path exec{};
   std::filesystem::path test_uri{};
   std::filesystem::path reference_uri{};

--- a/test/fuzzer/src/include/hictk/fuzzer/config.hpp
+++ b/test/fuzzer/src/include/hictk/fuzzer/config.hpp
@@ -30,6 +30,7 @@ struct Config {
   std::optional<std::uint64_t> seed{};
   std::size_t nproc{1};
   bool suppress_python_warnings{true};
+  std::int16_t verbosity{3};
 };
 // NOLINTEND(*-avoid-magic-numbers)
 

--- a/test/fuzzer/src/main.cpp
+++ b/test/fuzzer/src/main.cpp
@@ -36,12 +36,13 @@ static void setup_logger_console() {
 }
 
 static void setup_logger_console(int verbosity_lvl, bool print_version) {
+  spdlog::set_level(spdlog::level::level_enum(verbosity_lvl));
   for (auto& sink : spdlog::default_logger()->sinks()) {
     sink->set_level(spdlog::level::level_enum(verbosity_lvl));
   }
 
   if (print_version) {
-    SPDLOG_INFO(FMT_STRING("[executor] Testing hictk v{}"), hictk::config::version::str());
+    SPDLOG_INFO(FMT_STRING("[executor] Fuzzying hictk v{}"), hictk::config::version::str());
   }
 }
 
@@ -49,7 +50,7 @@ static std::tuple<int, Cli::subcommand, Config> parse_cli_and_setup_logger(Cli& 
   try {
     auto config = cli.parse_arguments();
     const auto subcmd = cli.get_subcommand();
-    setup_logger_console(spdlog::level::info, subcmd == Cli::subcommand::fuzz);
+    setup_logger_console(config.verbosity, subcmd == Cli::subcommand::fuzz);
     return std::make_tuple(cli.exit(), subcmd, config);
   } catch (const CLI::ParseError& e) {
     //  This takes care of formatting and printing error messages (if any)

--- a/test/fuzzer/src/main.cpp
+++ b/test/fuzzer/src/main.cpp
@@ -42,7 +42,7 @@ static void setup_logger_console(int verbosity_lvl, bool print_version) {
   }
 
   if (print_version) {
-    SPDLOG_INFO(FMT_STRING("[executor] Fuzzying hictk v{}"), hictk::config::version::str());
+    SPDLOG_INFO(FMT_STRING("[executor] Fuzzing hictk v{}"), hictk::config::version::str());
   }
 }
 


### PR DESCRIPTION
Well... it turns out that due to a typo (https://github.com/paulsengroup/hictk/commit/6c2a642055c2a0b917810e551e605a52b426856c) the tests covering .hic files were not working as intended.

Once the typo was fixed, it became clear that `hic2cool.hic2ckkl_extractnorms` (which is used as part of the [script](https://github.com/paulsengroup/hictk/blob/main/test/fuzzer/scripts/create_datasets_for_fuzzer.py) to generate matched datasets for fuzzing) is buggy.

```console
user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.hic9 --resolution 50000 --balance SCALE --join --range chr1 --range2 chr1 | head

chr1	0	50000	chr1	0	50000	73337.7265625
chr1	0	50000	chr1	50000	100000	3788.1474609375
chr1	0	50000	chr1	150000	200000	15372.154296875
chr1	0	50000	chr1	250000	300000	863.2742919921875
chr1	0	50000	chr1	600000	650000	320.6240844726562
chr1	0	50000	chr1	800000	850000	181.2357482910156
chr1	0	50000	chr1	1200000	1250000	72.47455596923828
chr1	0	50000	chr1	3850000	3900000	49.82170867919922
chr1	0	50000	chr1	6400000	6450000	45.85749435424805
chr1	0	50000	chr1	10100000	10150000	55.68156051635742

user@dev:/tmp$ straw observed SCALE 4DNFIYECESRC.50000.hic9 chr1 chr1 BP 50000 | sort -V | head

0	0	73337.7265625
0	50000	3788.1474609375
0	150000	15372.154296875
0	250000	863.27429199219
0	600000	320.62408447266
0	800000	181.2357635498
0	1200000	72.474555969238
0	3850000	49.821708679199
0	6400000	45.857494354248
0	10100000	55.681560516357

user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.cool --balance SCALE --join --range chr1 --range2 chr1 | head

chr1	0	50000	chr1	0	50000	73326.47095104467
chr1	0	50000	chr1	50000	100000	3787.671117122592
chr1	0	50000	chr1	150000	200000	15369.88791052104
chr1	0	50000	chr1	250000	300000	863.1946134691881
chr1	0	50000	chr1	600000	650000	320.5992394599785
chr1	0	50000	chr1	800000	850000	181.2220165658271
chr1	0	50000	chr1	1200000	1250000	72.46910509393064
chr1	0	50000	chr1	3850000	3900000	49.81796074382814
chr1	0	50000	chr1	6400000	6450000	45.8540617839616
chr1	0	50000	chr1	10100000	10150000	55.67740163217622
```

Indeed dumping the weights with `hictk` shows that the weights do not match:

```console
user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.hic9 --resolution 50000 --table weights | head

GW_SCALE	GW_VC	INTER_SCALE	INTER_VC	SCALE	VC	VC_SQRT
0.026283109560608864	0.025766246020793915	0.05174751207232475	0.046523503959178925	0.01609581895172596	0.0024648411199450493	0.03344287723302841
0.09203214943408966	0.12651462852954865	0.20558251440525055	0.2271459698677063	0.049201834946870804	0.01302221417427063	0.07686905562877655
0.12427109479904175	0.18209722638130188	0.30621588230133057	0.3252060115337372	0.05639198422431946	0.019980482757091522	0.09521647542715073
0.1299455314874649	0.17877204716205597	0.26928457617759705	0.3199484348297119	0.06870701909065247	0.019129784777760506	0.09316744655370712
0.00203463202342391	0.004034347832202911	0.005303055513650179	0.007427865639328957	0.00011479311069706455	0.0002835658087860793	0.011343211866915226
0.1567896157503128	0.24953073263168335	0.3707886040210724	0.451296329498291	0.07196778059005737	0.02333964593708515	0.10290969163179398
nan	0	nan	0	nan	0	0
0.006109944544732571	0.006729166489094496	0.011837385594844818	0.012318640947341919	0.003740387037396431	0.0005235060816630721	0.015412391163408756
0.0015248165000230074	0.0027893735095858574	0.004137048963457346	0.00501304492354393	0.00026468493160791695	0.0002835658087860793	0.011343211866915226

user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.cool --table weights | head

GW_KR	GW_SCALE	GW_VC	INTER_KR	INTER_SCALE	INTER_VC	KR	SCALE	VC	VC_SQRT	weight
nan	0.026283105302777974	0.02576624616980936	nan	0.05174750669380793	0.04652350389172373	0.016077572494580136	0.016097054281872813	0.002464841208774858	0.03344287517808673	nan
nan	0.09203213620927271	0.12651463256955936	nan	0.2055825168981054	0.22714596413889557	0.04944104865343332	0.049204246315782255	0.013022214173792832	0.07686905671137546	nan
nan	0.12427109352074223	0.18209723210528878	nan	0.3062158741143685	0.32520601701974294	0.05673619544218485	0.056392611603664815	0.019980482718918315	0.09521648015690835	nan
nan	0.1299455137404352	0.17877204681976597	nan	0.26928457985832055	0.319948433137104	0.068710662054193	0.06871187703332783	0.01912978531058009	0.09316744439070311	nan
nan	0.002034631888335365	0.004034348024141404	nan	0.005303055457039178	0.00742786560163526	nan	0.000114792916286769250.00028356580277940843	0.011343212348891936	nan
nan	0.15678961921691245	0.24953072896193357	nan	0.37078859850963075	0.4512963281586131	0.06307208106921801	0.0719689008334027	0.023339646844151306	0.1029096911932976	nan
nan	nan	0	nan	nan	0	nan	nan	0	0	nan
nan	0.006109943776999134	0.0067291664308921076	nan	0.011837385115403764	0.01231864130641568	nan	0.0037404472881887017	0.0005235060974389078	0.015412390603290858	nan
nan	0.0015248164032957328	0.0027893734385665177	nan	0.004137049070509011	0.005013045097399929	nan	0.0002646855687286078	0.00028356580277940843	0.011343212348891936	nan
```

However, converting the same file with `hictk convert` leads to the expected result:

```console
user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.hictk.cool --balance SCALE --join --range chr1 --range2 chr1 | head

chr1	0	50000	chr1	0	50000	73337.72677796868
chr1	0	50000	chr1	50000	100000	3788.147462249335
chr1	0	50000	chr1	150000	200000	15372.15434075431
chr1	0	50000	chr1	250000	300000	863.2742998040474
chr1	0	50000	chr1	600000	650000	320.6240729395666
chr1	0	50000	chr1	800000	850000	181.2357592998512
chr1	0	50000	chr1	1200000	1250000	72.47455715122292
chr1	0	50000	chr1	3850000	3900000	49.82170744039169
chr1	0	50000	chr1	6400000	6450000	45.85749467000802
chr1	0	50000	chr1	10100000	10150000	55.68156241977521

user@dev:/tmp$ hictk dump 4DNFIYECESRC.50000.hictk.cool --resolution 50000 --table weights | head

GW_SCALE	GW_VC	INTER_SCALE	INTER_VC	SCALE	VC	VC_SQRT
0.026283109560608864	0.025766246020793915	0.05174751207232475	0.046523503959178925	0.01609581895172596	0.0024648411199450493	0.03344287723302841
0.09203214943408966	0.12651462852954865	0.20558251440525055	0.2271459698677063	0.049201834946870804	0.01302221417427063	0.07686905562877655
0.12427109479904175	0.18209722638130188	0.30621588230133057	0.3252060115337372	0.05639198422431946	0.019980482757091522	0.09521647542715073
0.1299455314874649	0.17877204716205597	0.26928457617759705	0.3199484348297119	0.06870701909065247	0.019129784777760506	0.09316744655370712
0.00203463202342391	0.004034347832202911	0.005303055513650179	0.007427865639328957	0.00011479311069706455	0.0002835658087860793	0.011343211866915226
0.1567896157503128	0.24953073263168335	0.3707886040210724	0.451296329498291	0.07196778059005737	0.02333964593708515	0.10290969163179398
nan	0	nan	0	nan	0	0
0.006109944544732571	0.006729166489094496	0.011837385594844818	0.012318640947341919	0.003740387037396431	0.0005235060816630721	0.015412391163408756
0.0015248165000230074	0.0027893735095858574	0.004137048963457346	0.00501304492354393	0.00026468493160791695	0.0002835658087860793	0.011343211866915226
```

So we need to regenerate most of the test datasets used for fuzzing... And I don't think there is a way to do that without involving `hictk`, which is not ideal.