### PR TITLE
Add option to exclude "ALL" chromosomes when calling nchroms() on .hic files

### DIFF
--- a/docs/cpp_api/generic.rst
+++ b/docs/cpp_api/generic.rst
@@ -65,7 +65,7 @@ File handle
 
   .. cpp:function:: [[nodiscard]] std::uint32_t resolution() const;
   .. cpp:function:: [[nodiscard]] std::uint64_t nbins() const;
-  .. cpp:function:: [[nodiscard]] std::uint64_t nchroms() const;
+  .. cpp:function:: [[nodiscard]] std::uint64_t nchroms(bool include_ALL = false) const;
 
   Accessors for common attributes.
   Calling any of these accessors does not involve any computation.

--- a/docs/cpp_api/hic.rst
+++ b/docs/cpp_api/hic.rst
@@ -70,7 +70,7 @@ File handle
 
   .. cpp:function:: [[nodiscard]] std::uint32_t resolution() const noexcept;
   .. cpp:function:: [[nodiscard]] std::uint64_t nbins() const;
-  .. cpp:function:: [[nodiscard]] std::uint64_t nchroms() const;
+  .. cpp:function:: [[nodiscard]] std::uint64_t nchroms(bool include_ALL = false) const;
   .. cpp:function:: [[nodiscard]] const std::string &assembly() const noexcept;
   .. cpp:function:: [[nodiscard]] const std::vector<std::uint32_t> &avail_resolutions() const noexcept;
   .. cpp:function:: [[nodiscard]] bool has_normalization(std::string_view normalization) const;

--- a/src/libhictk/file/include/hictk/file.hpp
+++ b/src/libhictk/file/include/hictk/file.hpp
@@ -147,7 +147,7 @@ class File {
 
   [[nodiscard]] std::uint32_t resolution() const;
   [[nodiscard]] std::uint64_t nbins() const;
-  [[nodiscard]] std::uint64_t nchroms() const;
+  [[nodiscard]] std::uint64_t nchroms(bool include_ALL = false) const;
 
   [[nodiscard]] PixelSelector fetch(
       const balancing::Method &normalization = balancing::Method::NONE()) const;

--- a/src/libhictk/file/include/hictk/impl/file_impl.hpp
+++ b/src/libhictk/file/include/hictk/impl/file_impl.hpp
@@ -327,9 +327,19 @@ inline std::uint64_t File::nbins() const {
   return std::visit([&](const auto& fp) { return fp.nbins(); }, _fp);
 }
 
-inline std::uint64_t File::nchroms() const {
+inline std::uint64_t File::nchroms(bool include_ALL) const {
   assert(!_fp.valueless_by_exception());
-  return std::visit([&](const auto& fp) { return fp.nchroms(); }, _fp);
+
+  return std::visit(
+      [&](const auto& fp) {
+        using T = remove_cvref_t<decltype(fp)>;
+        if constexpr (std::is_same_v<hic::File, T>) {
+          return fp.nchroms(include_ALL);
+        } else {
+          return fp.nchroms();
+        }
+      },
+      _fp);
 }
 
 inline PixelSelector File::fetch(const balancing::Method& normalization) const {

--- a/src/libhictk/hic/include/hictk/hic.hpp
+++ b/src/libhictk/hic/include/hictk/hic.hpp
@@ -56,7 +56,7 @@ class File {
   [[nodiscard]] const BinTable &bins() const noexcept;
   [[nodiscard]] std::shared_ptr<const BinTable> bins_ptr() const noexcept;
   [[nodiscard]] std::uint64_t nbins() const;
-  [[nodiscard]] std::uint64_t nchroms() const;
+  [[nodiscard]] std::uint64_t nchroms(bool include_ALL = false) const;
   [[nodiscard]] const std::string &assembly() const noexcept;
   [[nodiscard]] const phmap::flat_hash_map<std::string, std::string> &attributes() const noexcept;
   [[nodiscard]] const std::vector<std::uint32_t> &avail_resolutions() const noexcept;

--- a/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
@@ -89,7 +89,12 @@ inline std::shared_ptr<const BinTable> File::bins_ptr() const noexcept { return 
 
 inline std::uint32_t File::resolution() const noexcept { return bins().resolution(); }
 inline std::uint64_t File::nbins() const { return bins().size(); }
-inline std::uint64_t File::nchroms() const { return chromosomes().size(); }
+inline std::uint64_t File::nchroms(bool include_ALL) const {
+  if (include_ALL) {
+    return chromosomes().size();
+  }
+  return chromosomes().remove_ALL().size();
+}
 
 inline const Reference& File::chromosomes() const noexcept { return bins().chromosomes(); }
 

--- a/test/units/file/file_test.cpp
+++ b/test/units/file/file_test.cpp
@@ -57,6 +57,7 @@ TEST_CASE("File", "[file][short]") {
       CHECK(hf.resolution() == ref_hic.resolution());
       CHECK(hf.nbins() == ref_hic.nbins());
       CHECK(hf.nchroms() == ref_hic.nchroms());
+      CHECK(hf.nchroms(true) == ref_hic.nchroms(true));
     }
 
     SECTION("cooler") {
@@ -72,6 +73,7 @@ TEST_CASE("File", "[file][short]") {
       CHECK(clr.resolution() == ref.resolution());
       CHECK(clr.nbins() == ref.nbins());
       CHECK(clr.nchroms() == ref.nchroms());
+      CHECK(clr.nchroms(true) == ref.nchroms());
     }
   }
 

--- a/test/units/hic/hic_file_test.cpp
+++ b/test/units/hic/hic_file_test.cpp
@@ -42,6 +42,9 @@ TEST_CASE("HiC: file accessors", "[hic][short]") {
   CHECK(f.name() == pathV8);
   CHECK(f.version() == 8);
   CHECK(f.chromosomes().size() == 9);
+  CHECK(f.nchroms(true) == 9);
+  CHECK(f.nchroms() == 8);
+  CHECK(f.nbins() == 137572);
   CHECK(f.assembly() == "dm6");
   CHECK(f.attributes().at("software") == "Juicer Tools Version 1.22.01");
 


### PR DESCRIPTION
Note that by default the `include_ALL` param is `false`, meaning that chromosomes named 'ALL' (case insensitive) will by default no longer be counted when calling `nchroms()` on .hic files.