### PR TITLE
Update linkcheck ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,8 +249,8 @@ latex_documents = [
 
 linkcheck_ignore = [
     r"https://github\.com/4dn-dcic/pairix/blob/master/pairs_format_specification\.md.*",
-    r"https://hictk.*\.org\.readthedocs\.build/.*",
-    r"https://hictk.*\.org/_/downloads/en/.*/pdf/",
+    r"https://hictk.*\.readthedocs\.build.*",
+    r"https://hictk.*readthedocs.*/_/downloads/en/.*/pdf/",
 ]
 
 primary_domain = "cpp"


### PR DESCRIPTION
It turns out https://github.com/paulsengroup/hictk/pull/297 is not enough because of redirects...

This is causing docs for v2.0.0 to fail to build :/.

Will probably release v2.0.1 soon just to have the stable docs pointing to the correct documentation version.