### PR TITLE
Improve throughput of float formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ target_compile_definitions(
   INTERFACE
     FMT_HEADER_ONLY
     FMT_ENFORCE_COMPILE_STRING
+    FMT_USE_FULL_CACHE_DRAGONBOX
 )
 # Tweak spdlog
 target_compile_definitions(hictk_project_options INTERFACE SPDLOG_FMT_EXTERNAL)


### PR DESCRIPTION
On my machine this gives a 4-5% performance boost when running e.g. `hictk dump file.cool --normalization weight > /dev/null`.