### PR TITLE
[docs]: add hgdownload.cse.ucsc.edu to linkcheck's ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,6 +249,7 @@ latex_documents = [
 
 linkcheck_ignore = [
     r"https://github\.com/4dn-dcic/pairix/blob/master/pairs_format_specification\.md.*",
+    r".*hgdownload\.cse\.ucsc\.edu.*",
     r"https://hictk.*\.readthedocs\.build.*",
     r"https://hictk.*readthedocs.*/_/downloads/en/.*/pdf/",
 ]


### PR DESCRIPTION
ReadTheDocs fails with "Temporary failure in name resolution" but I tried to visit the offending link using various combinations of machines and networks without any issues.