### PR TITLE
[testing]: catch2: don't report successes when invoked by CTest

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -400,8 +400,7 @@ jobs:
                 --schedule-random   \
                 --output-on-failure \
                 --no-tests=error    \
-                --timeout 400 2>&1 |
-          head -n 1000
+                --timeout 240
 
   run-integration-tests:
     name: Run integration tests

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -444,9 +444,8 @@ jobs:
                 --schedule-random           \
                 --output-on-failure         \
                 --no-tests=error            \
-                --timeout 360               \
-                -j $(nproc) |&
-          head -n 1000
+                --timeout 240               \
+                -j $(nproc)
 
   run-integration-tests:
     name: Run integration tests

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -234,34 +234,13 @@ jobs:
       - name: Install test dependencies
         run: pip install -r requirements.txt
 
-      - name: Run unit tests (Debug)
-        if: matrix.build_type == 'Debug'
-        run: |
-          skip_labels=(
-            '.*dataset large read\/write.*'
-            '.*HiCFileWriter.*'
-            '.*VectorOfAtomicDecimals.*'
-          )
-
-          pattern="$(IFS='|' ; echo "${skip_labels[*]}")"
-
-          ctest --test-dir build    \
-                --schedule-random   \
-                --output-on-failure \
-                --no-tests=error    \
-                --timeout 360       \
-                --exclude-regex "$pattern" |&
-          tail -n 1000
-
-      - name: Run unit tests (Release)
-        if: matrix.build_type == 'Release'
+      - name: Run unit tests
         run: |
           ctest --test-dir build    \
                 --schedule-random   \
                 --output-on-failure \
                 --no-tests=error    \
-                --timeout 120       |&
-          tail -n 1000
+                --timeout 240
 
   run-integration-tests:
     name: Run integration tests

--- a/test/units/balancing/CMakeLists.txt
+++ b/test/units/balancing/CMakeLists.txt
@@ -44,6 +44,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/bin_table/CMakeLists.txt
+++ b/test/units/bin_table/CMakeLists.txt
@@ -45,6 +45,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/binary_buffer/CMakeLists.txt
+++ b/test/units/binary_buffer/CMakeLists.txt
@@ -37,6 +37,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/chromosome/CMakeLists.txt
+++ b/test/units/chromosome/CMakeLists.txt
@@ -38,6 +38,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/cooler/CMakeLists.txt
+++ b/test/units/cooler/CMakeLists.txt
@@ -68,6 +68,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/cooler/dataset_large_rw_test.cpp
+++ b/test/units/cooler/dataset_large_rw_test.cpp
@@ -45,14 +45,7 @@ TEST_CASE("Cooler: dataset large read/write", "[dataset][long]") {
   std::for_each(dset.begin<std::uint8_t>(256'000), dset.end<std::uint8_t>(256'000),
                 [&](const auto& n1) {
                   const auto n2 = static_cast<std::uint8_t>(rand_eng());
-#ifdef _MSC_VER
-                  // The CHECK macros appear to be too slow under MSVC
-                  if (n1 != n2) {
-                    CHECK(n1 == n2);
-                  }
-#else
-                    CHECK(n1 == n2);
-#endif
+                  CHECK(n1 == n2);
                 });
 }
 // NOLINTEND(*-avoid-magic-numbers, readability-function-cognitive-complexity)

--- a/test/units/expected_values_aggregator/CMakeLists.txt
+++ b/test/units/expected_values_aggregator/CMakeLists.txt
@@ -42,6 +42,5 @@ catch_discover_tests(
   OUTPUT_DIR
   ${CMAKE_CURRENT_BINARY_DIR}/Testing/
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/file/CMakeLists.txt
+++ b/test/units/file/CMakeLists.txt
@@ -42,6 +42,5 @@ catch_discover_tests(
   OUTPUT_DIR
   ${CMAKE_CURRENT_BINARY_DIR}/Testing/
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/filestream/CMakeLists.txt
+++ b/test/units/filestream/CMakeLists.txt
@@ -37,6 +37,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/hic/CMakeLists.txt
+++ b/test/units/hic/CMakeLists.txt
@@ -46,6 +46,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/pixel/CMakeLists.txt
+++ b/test/units/pixel/CMakeLists.txt
@@ -38,6 +38,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/reference/CMakeLists.txt
+++ b/test/units/reference/CMakeLists.txt
@@ -37,6 +37,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/transformers/CMakeLists.txt
+++ b/test/units/transformers/CMakeLists.txt
@@ -47,6 +47,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )

--- a/test/units/variant/CMakeLists.txt
+++ b/test/units/variant/CMakeLists.txt
@@ -37,6 +37,5 @@ catch_discover_tests(
   OUTPUT_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/Testing/"
   EXTRA_ARGS
-  --success
   --skip-benchmarks
 )


### PR DESCRIPTION
This should reduce the time required to run the unit test suite.