### PR TITLE
[bug]: fix handling of Cooler v2 files lacking the "storage-mode" attribute

### DIFF
--- a/src/libhictk/cooler/include/hictk/cooler/impl/file_read_impl.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/impl/file_read_impl.hpp
@@ -522,6 +522,10 @@ inline auto File::read_standard_attributes(const RootGroup &root_grp, bool initi
     read_or_throw("bin-size", attrs.bin_size);
   }
   internal::read_optional(root_grp, "storage-mode", attrs.storage_mode, missing_ok);
+  if (!attrs.storage_mode.has_value()) {
+    assert(attrs.format_version < 3);
+    attrs.storage_mode = "symmetric-upper";
+  }
 
   // Try to read reserved attributes
   missing_ok = true;


### PR DESCRIPTION
According to Cooler [docs](https://cooler.readthedocs.io/en/latest/schema.html):
> Version 3 introduces the storage-mode metadata attribute to accomodate square matrices that are non-symmetric. Version 2 files which lack the storage-mode attribute should be interpreted as using the “symmetric-upper” storage mode. See [Storage mode](https://cooler.readthedocs.io/en/latest/schema.html#storage-mode).

Given this, the check we had in place was too strict.