### PR TITLE
[feature]: use CMake lock files when downloading or generating files

### DIFF
--- a/cmake/FetchTestDataset.cmake
+++ b/cmake/FetchTestDataset.cmake
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/test/data/")
-file(LOCK "${PROJECT_SOURCE_DIR}/test/data/" DIRECTORY GUARD FILE)
+if(NOT WIN32)
+  file(LOCK "${PROJECT_SOURCE_DIR}/test/data/" DIRECTORY GUARD FILE)
+endif()
 
 # gersemi: off
 file(

--- a/cmake/FetchTestDataset.cmake
+++ b/cmake/FetchTestDataset.cmake
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/test/data/")
+file(LOCK "${PROJECT_SOURCE_DIR}/test/data/" DIRECTORY GUARD FILE)
+
 # gersemi: off
 file(
   DOWNLOAD https://zenodo.org/records/13851354/files/hictk_test_data.tar.zst?download=1

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -20,7 +20,6 @@ endif()
 function(ConfigureVersioning input_config_folder output_config_folder)
   set(PRE_CONFIGURE_FILE "${input_config_folder}/git.hpp.in")
   set(POST_CONFIGURE_FILE "${output_config_folder}/git.hpp")
-  file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION TIMEOUT 10)
 
   if(HICTK_ENABLE_GIT_VERSION_TRACKING)
     include(FetchContent)
@@ -72,13 +71,18 @@ function(ConfigureVersioning input_config_folder output_config_folder)
       set(GIT_TAG "unknown")
     endif()
 
+    if(NOT WIN32)
+      file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION)
+    endif()
     configure_file("${PRE_CONFIGURE_FILE}" "${POST_CONFIGURE_FILE}" @ONLY)
   endif()
 
   set(PRE_CONFIGURE_FILE "${input_config_folder}/version.hpp.in")
   set(POST_CONFIGURE_FILE "${output_config_folder}/version.hpp")
-  file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION TIMEOUT 10)
 
+  if(NOT WIN32)
+    file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION)
+  endif()
   configure_file("${PRE_CONFIGURE_FILE}" "${POST_CONFIGURE_FILE}" @ONLY)
 endfunction()
 

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -20,7 +20,7 @@ endif()
 function(ConfigureVersioning input_config_folder output_config_folder)
   set(PRE_CONFIGURE_FILE "${input_config_folder}/git.hpp.in")
   set(POST_CONFIGURE_FILE "${output_config_folder}/git.hpp")
-  file(TOUCH ${POST_CONFIGURE_FILE})
+  file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION TIMEOUT 10)
 
   if(HICTK_ENABLE_GIT_VERSION_TRACKING)
     include(FetchContent)
@@ -77,8 +77,8 @@ function(ConfigureVersioning input_config_folder output_config_folder)
 
   set(PRE_CONFIGURE_FILE "${input_config_folder}/version.hpp.in")
   set(POST_CONFIGURE_FILE "${output_config_folder}/version.hpp")
+  file(LOCK "${POST_CONFIGURE_FILE}" GUARD FUNCTION TIMEOUT 10)
 
-  file(TOUCH "${POST_CONFIGURE_FILE}")
   configure_file("${PRE_CONFIGURE_FILE}" "${POST_CONFIGURE_FILE}" @ONLY)
 endfunction()
 


### PR DESCRIPTION
This makes it possible to configure multiple builds at once using the same source tree without incurring into random IO errors.