### PR TITLE
[build system]: prefix internal CMake targets with hictk_ to avoid collisions for common names

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -36,24 +36,44 @@ endforeach()
 install(
   TARGETS
     libhictk
-    hictk_balancing
-    hictk_bin_table
-    hictk_binary_buffer
-    hictk_chromosome
-    hictk_common
-    hictk_cooler
-    hictk_expected_values_aggregator
-    hictk_file
-    hictk_filestream
-    hictk_formatting
-    hictk_genomic_interval
-    hictk_hic
-    hictk_numeric
-    hictk_pixel
-    hictk_reference
-    hictk_transformers
-    hictk_variant
   EXPORT libhictk-targets
+  COMPONENT Libraries
+  FILE_SET
+  HEADERS
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  RUNTIME
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  PUBLIC_HEADER
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  PRIVATE_HEADER
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(
+  TARGETS
+    hictk_internal_balancing
+    hictk_internal_bin_table
+    hictk_internal_binary_buffer
+    hictk_internal_chromosome
+    hictk_internal_common
+    hictk_internal_cooler
+    hictk_internal_expected_values_aggregator
+    hictk_internal_file
+    hictk_internal_filestream
+    hictk_internal_formatting
+    hictk_internal_genomic_interval
+    hictk_internal_hic
+    hictk_internal_numeric
+    hictk_internal_pixel
+    hictk_internal_reference
+    hictk_internal_transformers
+    hictk_internal_variant
+  EXPORT libhictk-internal-targets
   COMPONENT Libraries
   FILE_SET
   HEADERS
@@ -76,6 +96,13 @@ install(
   COMPONENT Libraries
   FILE hictkTargets.cmake
   NAMESPACE hictk::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hictk/"
+)
+
+install(
+  EXPORT libhictk-internal-targets
+  COMPONENT Libraries
+  FILE hictkInternalTargets.cmake
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hictk/"
 )
 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -4,7 +4,23 @@
 
 set(
   targets
-  balancing;bin_table;binary_buffer;chromosome;common;cooler;expected_values_aggregator;file;filestream;formatting;genomic_interval;hic;numeric;pixel;reference;transformers;variant
+  balancing
+  bin_table
+  binary_buffer
+  chromosome
+  common
+  cooler
+  expected_values_aggregator
+  file
+  filestream
+  formatting
+  genomic_interval
+  hic
+  numeric
+  pixel
+  reference
+  transformers
+  variant
 )
 
 include(GNUInstallDirs)
@@ -20,23 +36,23 @@ endforeach()
 install(
   TARGETS
     libhictk
-    balancing
-    bin_table
-    binary_buffer
-    chromosome
-    common
-    cooler
-    expected_values_aggregator
-    file
-    filestream
-    formatting
-    genomic_interval
-    hic
-    numeric
-    pixel
-    reference
-    transformers
-    variant
+    hictk_balancing
+    hictk_bin_table
+    hictk_binary_buffer
+    hictk_chromosome
+    hictk_common
+    hictk_cooler
+    hictk_expected_values_aggregator
+    hictk_file
+    hictk_filestream
+    hictk_formatting
+    hictk_genomic_interval
+    hictk_hic
+    hictk_numeric
+    hictk_pixel
+    hictk_reference
+    hictk_transformers
+    hictk_variant
   EXPORT libhictk-targets
   COMPONENT Libraries
   FILE_SET

--- a/cmake/hictkConfig.cmake.in
+++ b/cmake/hictkConfig.cmake.in
@@ -38,6 +38,7 @@ find_dependency(span-lite CONFIG QUIET REQUIRED)
 find_dependency(spdlog CONFIG QUIET REQUIRED)
 find_dependency(zstd CONFIG QUIET REQUIRED)
 
+include("${CMAKE_CURRENT_LIST_DIR}/hictkInternalTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/hictkTargets.cmake")
 
 check_required_components(hictk)

--- a/src/libhictk/balancing/CMakeLists.txt
+++ b/src/libhictk/balancing/CMakeLists.txt
@@ -7,24 +7,24 @@ find_package(phmap REQUIRED)
 find_package(span-lite REQUIRED)
 find_package(zstd REQUIRED)
 
-add_library(balancing INTERFACE)
-add_library(hictk::balancing ALIAS balancing)
+add_library(hictk_balancing INTERFACE)
+add_library(hictk::balancing ALIAS hictk_balancing)
 
 target_sources(
-  balancing
+  hictk_balancing
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  balancing
+  hictk_balancing
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  balancing
+  hictk_balancing
   INTERFACE
     hictk::common
     hictk::filestream
@@ -32,7 +32,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  balancing
+  hictk_balancing
   INTERFACE
   bshoshany-thread-pool::bshoshany-thread-pool
   nonstd::span-lite
@@ -40,4 +40,4 @@ target_link_system_libraries(
   "zstd::libzstd_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>"
 )
 
-target_compile_definitions(balancing INTERFACE span_FEATURE_MAKE_SPAN=1)
+target_compile_definitions(hictk_balancing INTERFACE span_FEATURE_MAKE_SPAN=1)

--- a/src/libhictk/balancing/CMakeLists.txt
+++ b/src/libhictk/balancing/CMakeLists.txt
@@ -7,24 +7,24 @@ find_package(phmap REQUIRED)
 find_package(span-lite REQUIRED)
 find_package(zstd REQUIRED)
 
-add_library(hictk_balancing INTERFACE)
-add_library(hictk::balancing ALIAS hictk_balancing)
+add_library(hictk_internal_balancing INTERFACE)
+add_library(hictk::balancing ALIAS hictk_internal_balancing)
 
 target_sources(
-  hictk_balancing
+  hictk_internal_balancing
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_balancing
+  hictk_internal_balancing
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_balancing
+  hictk_internal_balancing
   INTERFACE
     hictk::common
     hictk::filestream
@@ -32,7 +32,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  hictk_balancing
+  hictk_internal_balancing
   INTERFACE
   bshoshany-thread-pool::bshoshany-thread-pool
   nonstd::span-lite
@@ -40,4 +40,4 @@ target_link_system_libraries(
   "zstd::libzstd_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>"
 )
 
-target_compile_definitions(hictk_balancing INTERFACE span_FEATURE_MAKE_SPAN=1)
+target_compile_definitions(hictk_internal_balancing INTERFACE span_FEATURE_MAKE_SPAN=1)

--- a/src/libhictk/bin_table/CMakeLists.txt
+++ b/src/libhictk/bin_table/CMakeLists.txt
@@ -2,24 +2,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_bin_table INTERFACE)
-add_library(hictk::bin_table ALIAS hictk_bin_table)
+add_library(hictk_internal_bin_table INTERFACE)
+add_library(hictk::bin_table ALIAS hictk_internal_bin_table)
 target_sources(
-  hictk_bin_table
+  hictk_internal_bin_table
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_bin_table
+  hictk_internal_bin_table
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  hictk_bin_table
+  hictk_internal_bin_table
   INTERFACE
     hictk::chromosome
     hictk::common

--- a/src/libhictk/bin_table/CMakeLists.txt
+++ b/src/libhictk/bin_table/CMakeLists.txt
@@ -2,24 +2,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(bin_table INTERFACE)
-add_library(hictk::bin_table ALIAS bin_table)
+add_library(hictk_bin_table INTERFACE)
+add_library(hictk::bin_table ALIAS hictk_bin_table)
 target_sources(
-  bin_table
+  hictk_bin_table
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  bin_table
+  hictk_bin_table
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  bin_table
+  hictk_bin_table
   INTERFACE
     hictk::chromosome
     hictk::common

--- a/src/libhictk/binary_buffer/CMakeLists.txt
+++ b/src/libhictk/binary_buffer/CMakeLists.txt
@@ -2,18 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(binary_buffer INTERFACE)
-add_library(hictk::binary_buffer ALIAS binary_buffer)
+add_library(hictk_binary_buffer INTERFACE)
+add_library(hictk::binary_buffer ALIAS hictk_binary_buffer)
 
 target_sources(
-  binary_buffer
+  hictk_binary_buffer
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  binary_buffer
+  hictk_binary_buffer
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"

--- a/src/libhictk/binary_buffer/CMakeLists.txt
+++ b/src/libhictk/binary_buffer/CMakeLists.txt
@@ -2,18 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_binary_buffer INTERFACE)
-add_library(hictk::binary_buffer ALIAS hictk_binary_buffer)
+add_library(hictk_internal_binary_buffer INTERFACE)
+add_library(hictk::binary_buffer ALIAS hictk_internal_binary_buffer)
 
 target_sources(
-  hictk_binary_buffer
+  hictk_internal_binary_buffer
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_binary_buffer
+  hictk_internal_binary_buffer
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"

--- a/src/libhictk/chromosome/CMakeLists.txt
+++ b/src/libhictk/chromosome/CMakeLists.txt
@@ -2,20 +2,20 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_chromosome INTERFACE)
-add_library(hictk::chromosome ALIAS hictk_chromosome)
+add_library(hictk_internal_chromosome INTERFACE)
+add_library(hictk::chromosome ALIAS hictk_internal_chromosome)
 
 target_sources(
-  hictk_chromosome
+  hictk_internal_chromosome
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_chromosome
+  hictk_internal_chromosome
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
-target_link_libraries(hictk_chromosome INTERFACE hictk::common)
+target_link_libraries(hictk_internal_chromosome INTERFACE hictk::common)

--- a/src/libhictk/chromosome/CMakeLists.txt
+++ b/src/libhictk/chromosome/CMakeLists.txt
@@ -2,20 +2,20 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(chromosome INTERFACE)
-add_library(hictk::chromosome ALIAS chromosome)
+add_library(hictk_chromosome INTERFACE)
+add_library(hictk::chromosome ALIAS hictk_chromosome)
 
 target_sources(
-  chromosome
+  hictk_chromosome
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  chromosome
+  hictk_chromosome
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
-target_link_libraries(chromosome INTERFACE hictk::common)
+target_link_libraries(hictk_chromosome INTERFACE hictk::common)

--- a/src/libhictk/common/CMakeLists.txt
+++ b/src/libhictk/common/CMakeLists.txt
@@ -7,26 +7,26 @@ find_package(libdeflate REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(zstd REQUIRED)
 
-add_library(hictk_common INTERFACE)
-add_library(hictk::common ALIAS hictk_common)
-add_dependencies(hictk_common _hictk_check_git)
+add_library(hictk_internal_common INTERFACE)
+add_library(hictk::common ALIAS hictk_internal_common)
+add_dependencies(hictk_internal_common _hictk_check_git)
 
 target_sources(
-  hictk_common
+  hictk_internal_common
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_common
+  hictk_internal_common
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  hictk_common
+  hictk_internal_common
   INTERFACE
     fmt::fmt-header-only
     "libdeflate::libdeflate_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>"

--- a/src/libhictk/common/CMakeLists.txt
+++ b/src/libhictk/common/CMakeLists.txt
@@ -7,26 +7,26 @@ find_package(libdeflate REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(zstd REQUIRED)
 
-add_library(common INTERFACE)
-add_library(hictk::common ALIAS common)
-add_dependencies(common _hictk_check_git)
+add_library(hictk_common INTERFACE)
+add_library(hictk::common ALIAS hictk_common)
+add_dependencies(hictk_common _hictk_check_git)
 
 target_sources(
-  common
+  hictk_common
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  common
+  hictk_common
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  common
+  hictk_common
   INTERFACE
     fmt::fmt-header-only
     "libdeflate::libdeflate_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>"

--- a/src/libhictk/cooler/CMakeLists.txt
+++ b/src/libhictk/cooler/CMakeLists.txt
@@ -13,24 +13,24 @@ if(HICTK_WITH_EIGEN)
   find_package(Eigen3 REQUIRED QUIET)
 endif()
 
-add_library(cooler INTERFACE)
-add_library(hictk::cooler ALIAS cooler)
+add_library(hictk_cooler INTERFACE)
+add_library(hictk::cooler ALIAS hictk_cooler)
 target_sources(
-  cooler
+  hictk_cooler
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  cooler
+  hictk_cooler
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  cooler
+  hictk_cooler
   INTERFACE
     hictk::balancing
     hictk::bin_table
@@ -45,7 +45,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  cooler
+  hictk_cooler
   INTERFACE
   "$<$<BOOL:${HICTK_WITH_EIGEN}>:Eigen3::Eigen>"
   FastFloat::fast_float

--- a/src/libhictk/cooler/CMakeLists.txt
+++ b/src/libhictk/cooler/CMakeLists.txt
@@ -9,28 +9,24 @@ find_package(HighFive REQUIRED)
 find_package(phmap REQUIRED)
 find_package(spdlog REQUIRED)
 
-if(HICTK_WITH_EIGEN)
-  find_package(Eigen3 REQUIRED QUIET)
-endif()
-
-add_library(hictk_cooler INTERFACE)
-add_library(hictk::cooler ALIAS hictk_cooler)
+add_library(hictk_internal_cooler INTERFACE)
+add_library(hictk::cooler ALIAS hictk_internal_cooler)
 target_sources(
-  hictk_cooler
+  hictk_internal_cooler
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_cooler
+  hictk_internal_cooler
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  hictk_cooler
+  hictk_internal_cooler
   INTERFACE
     hictk::balancing
     hictk::bin_table
@@ -45,9 +41,8 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  hictk_cooler
+  hictk_internal_cooler
   INTERFACE
-  "$<$<BOOL:${HICTK_WITH_EIGEN}>:Eigen3::Eigen>"
   FastFloat::fast_float
   fmt::fmt-header-only
   HDF5::HDF5

--- a/src/libhictk/expected_values_aggregator/CMakeLists.txt
+++ b/src/libhictk/expected_values_aggregator/CMakeLists.txt
@@ -5,24 +5,24 @@
 find_package(phmap REQUIRED)
 find_package(spdlog REQUIRED)
 
-add_library(expected_values_aggregator INTERFACE)
-add_library(hictk::expected_values_aggregator ALIAS expected_values_aggregator)
+add_library(hictk_expected_values_aggregator INTERFACE)
+add_library(hictk::expected_values_aggregator ALIAS hictk_expected_values_aggregator)
 
 target_sources(
-  expected_values_aggregator
+  hictk_expected_values_aggregator
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  expected_values_aggregator
+  hictk_expected_values_aggregator
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  expected_values_aggregator
+  hictk_expected_values_aggregator
   INTERFACE
     hictk::common
     hictk::chromosome
@@ -32,7 +32,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  expected_values_aggregator
+  hictk_expected_values_aggregator
   INTERFACE
   phmap
   spdlog::spdlog_header_only

--- a/src/libhictk/expected_values_aggregator/CMakeLists.txt
+++ b/src/libhictk/expected_values_aggregator/CMakeLists.txt
@@ -5,24 +5,24 @@
 find_package(phmap REQUIRED)
 find_package(spdlog REQUIRED)
 
-add_library(hictk_expected_values_aggregator INTERFACE)
-add_library(hictk::expected_values_aggregator ALIAS hictk_expected_values_aggregator)
+add_library(hictk_internal_expected_values_aggregator INTERFACE)
+add_library(hictk::expected_values_aggregator ALIAS hictk_internal_expected_values_aggregator)
 
 target_sources(
-  hictk_expected_values_aggregator
+  hictk_internal_expected_values_aggregator
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_expected_values_aggregator
+  hictk_internal_expected_values_aggregator
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_expected_values_aggregator
+  hictk_internal_expected_values_aggregator
   INTERFACE
     hictk::common
     hictk::chromosome
@@ -32,7 +32,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  hictk_expected_values_aggregator
+  hictk_internal_expected_values_aggregator
   INTERFACE
   phmap
   spdlog::spdlog_header_only

--- a/src/libhictk/file/CMakeLists.txt
+++ b/src/libhictk/file/CMakeLists.txt
@@ -4,24 +4,24 @@
 
 find_package(FMT REQUIRED)
 
-add_library(file INTERFACE)
-add_library(hictk::file ALIAS file)
+add_library(hictk_file INTERFACE)
+add_library(hictk::file ALIAS hictk_file)
 
 target_sources(
-  file
+  hictk_file
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  file
+  hictk_file
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  file
+  hictk_file
   INTERFACE
     hictk::balancing
     hictk::cooler
@@ -29,4 +29,4 @@ target_link_libraries(
     hictk::reference
 )
 
-target_link_system_libraries(file INTERFACE fmt::fmt-header-only)
+target_link_system_libraries(hictk_file INTERFACE fmt::fmt-header-only)

--- a/src/libhictk/file/CMakeLists.txt
+++ b/src/libhictk/file/CMakeLists.txt
@@ -4,24 +4,24 @@
 
 find_package(FMT REQUIRED)
 
-add_library(hictk_file INTERFACE)
-add_library(hictk::file ALIAS hictk_file)
+add_library(hictk_internal_file INTERFACE)
+add_library(hictk::file ALIAS hictk_internal_file)
 
 target_sources(
-  hictk_file
+  hictk_internal_file
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_file
+  hictk_internal_file
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_file
+  hictk_internal_file
   INTERFACE
     hictk::balancing
     hictk::cooler
@@ -29,4 +29,4 @@ target_link_libraries(
     hictk::reference
 )
 
-target_link_system_libraries(hictk_file INTERFACE fmt::fmt-header-only)
+target_link_system_libraries(hictk_internal_file INTERFACE fmt::fmt-header-only)

--- a/src/libhictk/filestream/CMakeLists.txt
+++ b/src/libhictk/filestream/CMakeLists.txt
@@ -5,21 +5,21 @@
 find_package(phmap REQUIRED)
 find_package(spdlog REQUIRED)
 
-add_library(filestream INTERFACE)
-add_library(hictk::filestream ALIAS filestream)
+add_library(hictk_filestream INTERFACE)
+add_library(hictk::filestream ALIAS hictk_filestream)
 
 target_sources(
-  filestream
+  hictk_filestream
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  filestream
+  hictk_filestream
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_libraries(filestream INTERFACE hictk::common)
+target_link_libraries(hictk_filestream INTERFACE hictk::common)

--- a/src/libhictk/filestream/CMakeLists.txt
+++ b/src/libhictk/filestream/CMakeLists.txt
@@ -5,21 +5,21 @@
 find_package(phmap REQUIRED)
 find_package(spdlog REQUIRED)
 
-add_library(hictk_filestream INTERFACE)
-add_library(hictk::filestream ALIAS hictk_filestream)
+add_library(hictk_internal_filestream INTERFACE)
+add_library(hictk::filestream ALIAS hictk_internal_filestream)
 
 target_sources(
-  hictk_filestream
+  hictk_internal_filestream
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_filestream
+  hictk_internal_filestream
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_libraries(hictk_filestream INTERFACE hictk::common)
+target_link_libraries(hictk_internal_filestream INTERFACE hictk::common)

--- a/src/libhictk/formatting/CMakeLists.txt
+++ b/src/libhictk/formatting/CMakeLists.txt
@@ -4,25 +4,25 @@
 
 find_package(FMT REQUIRED)
 
-add_library(hictk_formatting INTERFACE)
-add_library(hictk::format ALIAS hictk_formatting)
+add_library(hictk_internal_formatting INTERFACE)
+add_library(hictk::format ALIAS hictk_internal_formatting)
 
 target_sources(
-  hictk_formatting
+  hictk_internal_formatting
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_formatting
+  hictk_internal_formatting
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  hictk_formatting
+  hictk_internal_formatting
   INTERFACE
     hictk::bin_table
     hictk::chromosome
@@ -31,4 +31,4 @@ target_link_libraries(
     hictk::pixel
 )
 
-target_link_system_libraries(hictk_formatting INTERFACE fmt::fmt-header-only)
+target_link_system_libraries(hictk_internal_formatting INTERFACE fmt::fmt-header-only)

--- a/src/libhictk/formatting/CMakeLists.txt
+++ b/src/libhictk/formatting/CMakeLists.txt
@@ -4,25 +4,25 @@
 
 find_package(FMT REQUIRED)
 
-add_library(formatting INTERFACE)
-add_library(hictk::format ALIAS formatting)
+add_library(hictk_formatting INTERFACE)
+add_library(hictk::format ALIAS hictk_formatting)
 
 target_sources(
-  formatting
+  hictk_formatting
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  formatting
+  hictk_formatting
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
 target_link_libraries(
-  formatting
+  hictk_formatting
   INTERFACE
     hictk::bin_table
     hictk::chromosome
@@ -31,4 +31,4 @@ target_link_libraries(
     hictk::pixel
 )
 
-target_link_system_libraries(formatting INTERFACE fmt::fmt-header-only)
+target_link_system_libraries(hictk_formatting INTERFACE fmt::fmt-header-only)

--- a/src/libhictk/genomic_interval/CMakeLists.txt
+++ b/src/libhictk/genomic_interval/CMakeLists.txt
@@ -2,24 +2,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(genomic_interval INTERFACE)
-add_library(hictk::genomic_interval ALIAS genomic_interval)
+add_library(hictk_genomic_interval INTERFACE)
+add_library(hictk::genomic_interval ALIAS hictk_genomic_interval)
 
 target_sources(
-  genomic_interval
+  hictk_genomic_interval
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  genomic_interval
+  hictk_genomic_interval
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  genomic_interval
+  hictk_genomic_interval
   INTERFACE
     hictk::chromosome
     hictk::common

--- a/src/libhictk/genomic_interval/CMakeLists.txt
+++ b/src/libhictk/genomic_interval/CMakeLists.txt
@@ -2,24 +2,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_genomic_interval INTERFACE)
-add_library(hictk::genomic_interval ALIAS hictk_genomic_interval)
+add_library(hictk_internal_genomic_interval INTERFACE)
+add_library(hictk::genomic_interval ALIAS hictk_internal_genomic_interval)
 
 target_sources(
-  hictk_genomic_interval
+  hictk_internal_genomic_interval
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_genomic_interval
+  hictk_internal_genomic_interval
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_genomic_interval
+  hictk_internal_genomic_interval
   INTERFACE
     hictk::chromosome
     hictk::common

--- a/src/libhictk/hic/CMakeLists.txt
+++ b/src/libhictk/hic/CMakeLists.txt
@@ -10,10 +10,6 @@ find_package(phmap REQUIRED)
 find_package(readerwriterqueue REQUIRED)
 find_package(zstd REQUIRED)
 
-if(HICTK_WITH_EIGEN)
-  find_package(Eigen3 QUIET REQUIRED)
-endif()
-
 set(HICTK_CXX_BYTE_ORDER "${CMAKE_CXX_BYTE_ORDER}" CACHE STRING "Specify the CPU architecture endianness")
 
 if(HICTK_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
@@ -28,24 +24,24 @@ else()
   )
 endif()
 
-add_library(hictk_hic INTERFACE)
-add_library(hictk::hic ALIAS hictk_hic)
+add_library(hictk_internal_hic INTERFACE)
+add_library(hictk::hic ALIAS hictk_internal_hic)
 
 target_sources(
-  hictk_hic
+  hictk_internal_hic
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_hic
+  hictk_internal_hic
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_hic
+  hictk_internal_hic
   INTERFACE
     hictk::balancing
     hictk::common
@@ -59,11 +55,10 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  hictk_hic
+  hictk_internal_hic
   INTERFACE
   bshoshany-thread-pool::bshoshany-thread-pool
   concurrentqueue::concurrentqueue
-  "$<$<BOOL:${HICTK_WITH_EIGEN}>:Eigen3::Eigen>"
   fmt::fmt-header-only
   "libdeflate::libdeflate_$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,shared,static>"
   phmap

--- a/src/libhictk/hic/CMakeLists.txt
+++ b/src/libhictk/hic/CMakeLists.txt
@@ -28,24 +28,24 @@ else()
   )
 endif()
 
-add_library(hic INTERFACE)
-add_library(hictk::hic ALIAS hic)
+add_library(hictk_hic INTERFACE)
+add_library(hictk::hic ALIAS hictk_hic)
 
 target_sources(
-  hic
+  hictk_hic
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hic
+  hictk_hic
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hic
+  hictk_hic
   INTERFACE
     hictk::balancing
     hictk::common
@@ -59,7 +59,7 @@ target_link_libraries(
 )
 
 target_link_system_libraries(
-  hic
+  hictk_hic
   INTERFACE
   bshoshany-thread-pool::bshoshany-thread-pool
   concurrentqueue::concurrentqueue

--- a/src/libhictk/numeric/CMakeLists.txt
+++ b/src/libhictk/numeric/CMakeLists.txt
@@ -4,20 +4,20 @@
 
 find_package(FastFloat REQUIRED)
 
-add_library(numeric INTERFACE)
-add_library(hictk::numeric ALIAS numeric)
+add_library(hictk_numeric INTERFACE)
+add_library(hictk::numeric ALIAS hictk_numeric)
 target_sources(
-  numeric
+  hictk_numeric
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  numeric
+  hictk_numeric
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_system_libraries(numeric INTERFACE FastFloat::fast_float)
+target_link_system_libraries(hictk_numeric INTERFACE FastFloat::fast_float)

--- a/src/libhictk/numeric/CMakeLists.txt
+++ b/src/libhictk/numeric/CMakeLists.txt
@@ -4,20 +4,20 @@
 
 find_package(FastFloat REQUIRED)
 
-add_library(hictk_numeric INTERFACE)
-add_library(hictk::numeric ALIAS hictk_numeric)
+add_library(hictk_internal_numeric INTERFACE)
+add_library(hictk::numeric ALIAS hictk_internal_numeric)
 target_sources(
-  hictk_numeric
+  hictk_internal_numeric
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_include_directories(
-  hictk_numeric
+  hictk_internal_numeric
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_system_libraries(hictk_numeric INTERFACE FastFloat::fast_float)
+target_link_system_libraries(hictk_internal_numeric INTERFACE FastFloat::fast_float)

--- a/src/libhictk/pixel/CMakeLists.txt
+++ b/src/libhictk/pixel/CMakeLists.txt
@@ -2,23 +2,23 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_pixel INTERFACE)
-add_library(hictk::pixel ALIAS hictk_pixel)
+add_library(hictk_internal_pixel INTERFACE)
+add_library(hictk::pixel ALIAS hictk_internal_pixel)
 
 target_sources(
-  hictk_pixel
+  hictk_internal_pixel
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  hictk_pixel
+  hictk_internal_pixel
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_pixel
+  hictk_internal_pixel
   INTERFACE
     hictk::bin_table
     hictk::chromosome

--- a/src/libhictk/pixel/CMakeLists.txt
+++ b/src/libhictk/pixel/CMakeLists.txt
@@ -2,23 +2,23 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(pixel INTERFACE)
-add_library(hictk::pixel ALIAS pixel)
+add_library(hictk_pixel INTERFACE)
+add_library(hictk::pixel ALIAS hictk_pixel)
 
 target_sources(
-  pixel
+  hictk_pixel
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  pixel
+  hictk_pixel
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  pixel
+  hictk_pixel
   INTERFACE
     hictk::bin_table
     hictk::chromosome

--- a/src/libhictk/reference/CMakeLists.txt
+++ b/src/libhictk/reference/CMakeLists.txt
@@ -4,27 +4,27 @@
 
 find_package(phmap REQUIRED)
 
-add_library(reference INTERFACE)
-add_library(hictk::reference ALIAS reference)
+add_library(hictk_reference INTERFACE)
+add_library(hictk::reference ALIAS hictk_reference)
 
 target_sources(
-  reference
+  hictk_reference
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  reference
+  hictk_reference
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  reference
+  hictk_reference
   INTERFACE
     hictk::chromosome
     hictk::common
     hictk::format
 )
 
-target_link_system_libraries(reference INTERFACE phmap)
+target_link_system_libraries(hictk_reference INTERFACE phmap)

--- a/src/libhictk/reference/CMakeLists.txt
+++ b/src/libhictk/reference/CMakeLists.txt
@@ -4,27 +4,27 @@
 
 find_package(phmap REQUIRED)
 
-add_library(hictk_reference INTERFACE)
-add_library(hictk::reference ALIAS hictk_reference)
+add_library(hictk_internal_reference INTERFACE)
+add_library(hictk::reference ALIAS hictk_internal_reference)
 
 target_sources(
-  hictk_reference
+  hictk_internal_reference
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  hictk_reference
+  hictk_internal_reference
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_reference
+  hictk_internal_reference
   INTERFACE
     hictk::chromosome
     hictk::common
     hictk::format
 )
 
-target_link_system_libraries(hictk_reference INTERFACE phmap)
+target_link_system_libraries(hictk_internal_reference INTERFACE phmap)

--- a/src/libhictk/transformers/CMakeLists.txt
+++ b/src/libhictk/transformers/CMakeLists.txt
@@ -6,35 +6,39 @@ if(HICTK_WITH_ARROW)
   find_package(Arrow REQUIRED QUIET)
 endif()
 
+if(HICTK_WITH_EIGEN)
+  find_package(Eigen3 REQUIRED QUIET)
+endif()
+
 find_package(spdlog REQUIRED QUIET)
 
-add_library(hictk_transformers INTERFACE)
-add_library(hictk::transformers ALIAS hictk_transformers)
+add_library(hictk_internal_transformers INTERFACE)
+add_library(hictk::transformers ALIAS hictk_internal_transformers)
 
 target_sources(
-  hictk_transformers
+  hictk_internal_transformers
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  hictk_transformers
+  hictk_internal_transformers
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  hictk_transformers
+  hictk_internal_transformers
   INTERFACE
     hictk::cooler
     hictk::file
     hictk::hic
 )
 
-target_link_system_libraries(hictk_transformers INTERFACE spdlog::spdlog_header_only)
+target_link_system_libraries(hictk_internal_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_EIGEN}>:Eigen3::Eigen>" spdlog::spdlog_header_only)
 
 if(HICTK_WITH_ARROW_SHARED)
-  target_link_system_libraries(hictk_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_shared>")
+  target_link_system_libraries(hictk_internal_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_shared>")
 else()
-  target_link_system_libraries(hictk_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_static>")
+  target_link_system_libraries(hictk_internal_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_static>")
 endif()

--- a/src/libhictk/transformers/CMakeLists.txt
+++ b/src/libhictk/transformers/CMakeLists.txt
@@ -8,33 +8,33 @@ endif()
 
 find_package(spdlog REQUIRED QUIET)
 
-add_library(transformers INTERFACE)
-add_library(hictk::transformers ALIAS transformers)
+add_library(hictk_transformers INTERFACE)
+add_library(hictk::transformers ALIAS hictk_transformers)
 
 target_sources(
-  transformers
+  hictk_transformers
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  transformers
+  hictk_transformers
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(
-  transformers
+  hictk_transformers
   INTERFACE
     hictk::cooler
     hictk::file
     hictk::hic
 )
 
-target_link_system_libraries(transformers INTERFACE spdlog::spdlog_header_only)
+target_link_system_libraries(hictk_transformers INTERFACE spdlog::spdlog_header_only)
 
 if(HICTK_WITH_ARROW_SHARED)
-  target_link_system_libraries(transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_shared>")
+  target_link_system_libraries(hictk_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_shared>")
 else()
-  target_link_system_libraries(transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_static>")
+  target_link_system_libraries(hictk_transformers INTERFACE "$<$<BOOL:${HICTK_WITH_ARROW}>:Arrow::arrow_static>")
 endif()

--- a/src/libhictk/variant/CMakeLists.txt
+++ b/src/libhictk/variant/CMakeLists.txt
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(variant INTERFACE)
-add_library(hictk::variant ALIAS variant)
+add_library(hictk_variant INTERFACE)
+add_library(hictk::variant ALIAS hictk_variant)
 
 target_sources(
-  variant
+  hictk_variant
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  variant
+  hictk_variant
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"

--- a/src/libhictk/variant/CMakeLists.txt
+++ b/src/libhictk/variant/CMakeLists.txt
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-add_library(hictk_variant INTERFACE)
-add_library(hictk::variant ALIAS hictk_variant)
+add_library(hictk_internal_variant INTERFACE)
+add_library(hictk::variant ALIAS hictk_internal_variant)
 
 target_sources(
-  hictk_variant
+  hictk_internal_variant
   INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 target_include_directories(
-  hictk_variant
+  hictk_internal_variant
   INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>"

--- a/test/packaging/test_add_subdirectory/conanfile.py
+++ b/test/packaging/test_add_subdirectory/conanfile.py
@@ -1,0 +1,1 @@
+../../../conanfile.py

--- a/test/packaging/test_add_subdirectory/main.cpp
+++ b/test/packaging/test_add_subdirectory/main.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 
+#include "hictk/transformers.hpp"
 #include "hictk/version.hpp"
 
 int main() { std::cout << hictk::config::version::str_long() << "\n"; }

--- a/test/packaging/test_find_package/README.md
+++ b/test/packaging/test_find_package/README.md
@@ -16,7 +16,7 @@ cmake --build hictk_build/
 cmake --install hictk_build/
 
 # Build test project
-cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/hictk_install/lib/cmake/hictk/"
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/hictk_install/lib/cmake/hictk/;$PWD/hictk_install/lib64/cmake/hictk/"
 cmake --build build/
 
 build/hictk_test_find_package

--- a/test/packaging/test_find_package/main.cpp
+++ b/test/packaging/test_find_package/main.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 
+#include "hictk/transformers.hpp"
 #include "hictk/version.hpp"
 
 int main() { std::cout << hictk::config::version::str_long() << "\n"; }


### PR DESCRIPTION
Closes https://github.com/paulsengroup/hictk/issues/314.