### PR TITLE
[fix]: do not wrap string literals with FMT_STRING when using SPDLOG_ macros

### DIFF
--- a/src/hictk/load/cool.hpp
+++ b/src/hictk/load/cool.hpp
@@ -116,7 +116,7 @@ template <typename N>
     std::string_view tmp_cooler_path, const BinTable& bins, std::string_view assembly,
     std::size_t batch_size, std::uint32_t compression_lvl, bool force, bool validate_pixels) {
   static_assert(std::is_same_v<N, std::int32_t> || std::is_same_v<N, double>);
-  SPDLOG_INFO(FMT_STRING("begin loading unsorted pixels into a .cool file..."));
+  SPDLOG_INFO("begin loading unsorted pixels into a .cool file...");
   Stats stats{N{}, 0};
   std::vector<ThinPixel<N>> write_buffer(batch_size);
 
@@ -160,7 +160,7 @@ template <typename N>
     const BinTable& bins, std::string_view assembly, std::size_t batch_size,
     std::uint32_t compression_lvl, bool force, bool validate_pixels) {
   static_assert(std::is_same_v<N, std::int32_t> || std::is_same_v<N, double>);
-  SPDLOG_INFO(FMT_STRING("begin loading pre-sorted pixels into a .cool file..."));
+  SPDLOG_INFO("begin loading pre-sorted pixels into a .cool file...");
   auto attrs = cooler::Attributes::init(bins.resolution());
   attrs.assembly = assembly;
   return ingest_pixels_sorted<N>(
@@ -175,7 +175,7 @@ template <typename N>
     std::string_view tmp_cooler_path, const BinTable& bins, std::string_view assembly,
     std::size_t batch_size, std::uint32_t compression_lvl, bool force, bool validate_pixels) {
   static_assert(std::is_same_v<N, std::int32_t> || std::is_same_v<N, double>);
-  SPDLOG_INFO(FMT_STRING("begin loading pairwise interactions into a .cool file..."));
+  SPDLOG_INFO("begin loading pairwise interactions into a .cool file...");
   std::vector<ThinPixel<N>> write_buffer(batch_size);
   {
     auto sclr_attrs = cooler::SingleCellAttributes::init(bins.resolution());

--- a/src/hictk/load/hic.cpp
+++ b/src/hictk/load/hic.cpp
@@ -113,7 +113,7 @@ Stats ingest_pixels_hic(PixelQueue<float>& pixel_queue, const std::atomic<bool>&
                         const std::string& assembly, bool skip_all_vs_all_matrix,
                         std::size_t threads, std::size_t batch_size, std::uint32_t compression_lvl,
                         bool force) {
-  SPDLOG_INFO(FMT_STRING("begin loading pixels into a .hic file..."));
+  SPDLOG_INFO("begin loading pixels into a .hic file...");
 
   if (force) {
     std::filesystem::remove(uri);  // NOLINT

--- a/src/hictk/load/init_bin_table.cpp
+++ b/src/hictk/load/init_bin_table.cpp
@@ -123,11 +123,11 @@ BinTable init_bin_table(const std::filesystem::path& path_to_bin_table) {
   std::sort(chroms.begin(), chroms.end());
 
   if (fixed_bin_size) {
-    SPDLOG_INFO(FMT_STRING("detected bin table with uniform bin size."));
+    SPDLOG_INFO("detected bin table with uniform bin size.");
     return {chroms.begin(), chroms.end(), bin_size};
   }
 
-  SPDLOG_INFO(FMT_STRING("detected bin table with variable bin size."));
+  SPDLOG_INFO("detected bin table with variable bin size.");
   return {Reference{chroms.begin(), chroms.end()}, start_pos, end_pos};
 }
 

--- a/src/hictk/load/load.hpp
+++ b/src/hictk/load/load.hpp
@@ -139,20 +139,19 @@ template <typename N>
                                                       std::int64_t offset,
                                                       std::atomic<bool>& early_return,
                                                       bool transpose_lower_triangular_pixels) {
-  return tpool.submit_task([&parser, &queue, offset, &early_return,
-                            transpose_lower_triangular_pixels]() {
-    try {
-      if (transpose_lower_triangular_pixels) {
-        return parse_pixels<true>(parser, offset, queue, early_return);
-      }
-      return parse_pixels<false>(parser, offset, queue, early_return);
-    } catch (...) {
-      SPDLOG_WARN(
-          FMT_STRING("exception caught in thread parsing interactions: returning immediately!"));
-      early_return = true;
-      throw;
-    }
-  });
+  return tpool.submit_task(
+      [&parser, &queue, offset, &early_return, transpose_lower_triangular_pixels]() {
+        try {
+          if (transpose_lower_triangular_pixels) {
+            return parse_pixels<true>(parser, offset, queue, early_return);
+          }
+          return parse_pixels<false>(parser, offset, queue, early_return);
+        } catch (...) {
+          SPDLOG_WARN("exception caught in thread parsing interactions: returning immediately!");
+          early_return = true;
+          throw;
+        }
+      });
 }
 
 template <typename N>

--- a/src/libhictk/balancing/include/hictk/balancing/impl/ice_impl.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/impl/ice_impl.hpp
@@ -182,7 +182,7 @@ inline void ICE::balance_cis(const MatrixT& matrix, const Chromosome& chrom, std
 template <typename File>
 auto ICE::construct_sparse_matrix(const File& f, Type type, std::size_t num_masked_diags)
     -> internal::SparseMatrixChunked {
-  SPDLOG_INFO(FMT_STRING("Reading interactions into memory..."));
+  SPDLOG_INFO("Reading interactions into memory...");
   if (type == Type::cis) {
     return construct_sparse_matrix_cis(f, num_masked_diags);
   }
@@ -627,7 +627,7 @@ inline void ICE::initialize_biases(const MatrixT& matrix, nonstd::span<double> b
     return;
   }
 
-  SPDLOG_INFO(FMT_STRING("Initializing bias vector..."));
+  SPDLOG_INFO("Initializing bias vector...");
   internal::VectorOfAtomicDecimals marg(biases.size());
   if (min_nnz != 0) {
     SPDLOG_INFO(FMT_STRING("Masking rows with fewer than {} nnz entries..."), min_nnz);

--- a/src/libhictk/balancing/include/hictk/balancing/impl/scale_impl.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/impl/scale_impl.hpp
@@ -129,7 +129,7 @@ inline void SCALE::balance(const Matrix& m, const BinTable& bins, const Params& 
     SPDLOG_INFO(FMT_STRING("Iteration {}: {}"), _tot_iter, _convergence_stats.error);
 
     if (_convergence_stats.error < params.tol) {
-      SPDLOG_DEBUG(FMT_STRING("handle_convergence"));
+      SPDLOG_DEBUG("handle_convergence");
       const auto status = handle_convergenece(m, dr, dc, row);
       if (status == ControlFlow::break_loop) {
         break;
@@ -151,7 +151,7 @@ inline void SCALE::balance(const Matrix& m, const BinTable& bins, const Params& 
     }
 
     // handle divergence
-    SPDLOG_DEBUG(FMT_STRING("handle_divergence"));
+    SPDLOG_DEBUG("handle_divergence");
     _convergence_stats.diverged = true;
     _convergence_stats.low_divergence = static_cast<std::uint32_t>(_low_cutoff);
     const auto status =
@@ -436,10 +436,10 @@ inline auto SCALE::handle_convergenece(const Matrix& m, std::vector<double>& dr,
                                        internal::VectorOfAtomicDecimals& row) -> ControlFlow {
   _yes = true;
   if (_low_cutoff == 1) {
-    SPDLOG_DEBUG(FMT_STRING("low cutoff"));
+    SPDLOG_DEBUG("low cutoff");
     return ControlFlow::break_loop;
   }
-  SPDLOG_DEBUG(FMT_STRING("non low cutoff"));
+  SPDLOG_DEBUG("non low cutoff");
   _convergence_stats.converged = true;
   _b_conv = _biases1;
   _bad_conv = _bad;

--- a/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/file_writer_impl.hpp
@@ -263,7 +263,7 @@ inline void HiCFileWriter::write_header() {
   assert(!chromosomes().empty());
 
   try {
-    SPDLOG_INFO(FMT_STRING("writing header at offset 0"));
+    SPDLOG_INFO("writing header at offset 0");
     const auto section_end = _fs.seek_and_write(0, _header.serialize(_bbuffer)).second;
 
     _header_section = {0, section_end};

--- a/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/interaction_to_block_mapper_impl.hpp
@@ -240,7 +240,7 @@ inline void HiCInteractionToBlockMapper::append_pixels(PixelIt first_pixel, Pixe
     return append_pixels(first_pixel, last_pixel);
   }
 
-  SPDLOG_DEBUG(FMT_STRING("mapping pixels to interaction blocks using 2 threads..."));
+  SPDLOG_DEBUG("mapping pixels to interaction blocks using 2 threads...");
 
   std::atomic<bool> early_return = false;
   // NOLINTNEXTLINE(*-avoid-magic-numbers)

--- a/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/serialized_block_pqueue_impl.hpp
@@ -99,13 +99,13 @@ inline auto SerializedBlockPQueue<BlockID>::dequeue_timed(std::chrono::milliseco
       }
     }
     SPDLOG_DEBUG(
-        FMT_STRING("SerializedBlockPQueue::dequeue_timed(): queue is empty. Sleeping before trying "
-                   "one more time..."));
+        "SerializedBlockPQueue::dequeue_timed(): queue is empty. Sleeping before trying one more "
+        "time...");
     // NOLINTNEXTLINE(*-avoid-magic-numbers)
     std::this_thread::sleep_for(timeout / 25);
   }
 
-  SPDLOG_DEBUG(FMT_STRING("SerializedBlockPQueue::dequeue_timed(): operation timed out"));
+  SPDLOG_DEBUG("SerializedBlockPQueue::dequeue_timed(): operation timed out");
   return {{}, "", Record::Status::TIMEOUT};
 }
 
@@ -128,8 +128,8 @@ template <typename BlockID>
 inline auto SerializedBlockPQueue<BlockID>::dequeue_unsafe() noexcept -> Record {
   if (HICTK_UNLIKELY(_block_ids.empty())) {
     SPDLOG_DEBUG(
-        FMT_STRING("SerializedBlockPQueue::dequeue_unsafe(): caught attempt to fetch block from a "
-                   "closed queue"));
+        "SerializedBlockPQueue::dequeue_unsafe(): caught attempt to fetch block from a closed "
+        "queue");
     return {{}, "", Record::Status::QUEUE_IS_CLOSED};
   }
 

--- a/test/fuzzer/src/fuzzer_scheduler.cpp
+++ b/test/fuzzer/src/fuzzer_scheduler.cpp
@@ -140,8 +140,7 @@ int fuzz_subcommand(const Config& c) {
     }
 
     if (exit_code != 0) {
-      SPDLOG_ERROR(
-          FMT_STRING("[executor] one or more worker process returned with non-zero exit code"));
+      SPDLOG_ERROR("[executor] one or more worker process returned with non-zero exit code");
     }
 
     return exit_code;


### PR DESCRIPTION
This prevents compilation errors when compiling hictk with spdlog v1.15.1.