### PR TITLE
[enhancement]: update ToDataFrame to use signed integers

### DIFF
--- a/src/libhictk/transformers/include/hictk/transformers/to_dataframe.hpp
+++ b/src/libhictk/transformers/include/hictk/transformers/to_dataframe.hpp
@@ -91,30 +91,30 @@ class ToDataFrame {
   bool _mirror_pixels{true};
 
   std::size_t _chunk_size{};
-  arrow::UInt64Builder _bin1_id_builder{};
-  arrow::UInt64Builder _bin2_id_builder{};
+  arrow::Int64Builder _bin1_id_builder{};
+  arrow::Int64Builder _bin2_id_builder{};
 
   arrow::StringDictionary32Builder _chrom1_builder{};
-  arrow::UInt32Builder _start1_builder{};
-  arrow::UInt32Builder _end1_builder{};
+  arrow::Int32Builder _start1_builder{};
+  arrow::Int32Builder _end1_builder{};
 
   arrow::StringDictionary32Builder _chrom2_builder{};
-  arrow::UInt32Builder _start2_builder{};
-  arrow::UInt32Builder _end2_builder{};
+  arrow::Int32Builder _start2_builder{};
+  arrow::Int32Builder _end2_builder{};
 
   using NBuilder = decltype(internal::map_cpp_type_to_arrow_builder<N>());
   NBuilder _count_builder{};
 
-  std::vector<std::uint64_t> _bin1_id_buff{};
-  std::vector<std::uint64_t> _bin2_id_buff{};
+  std::vector<std::int64_t> _bin1_id_buff{};
+  std::vector<std::int64_t> _bin2_id_buff{};
 
   std::vector<std::int32_t> _chrom1_id_buff{};
-  std::vector<std::uint32_t> _start1_buff{};
-  std::vector<std::uint32_t> _end1_buff{};
+  std::vector<std::int32_t> _start1_buff{};
+  std::vector<std::int32_t> _end1_buff{};
 
   std::vector<std::int32_t> _chrom2_id_buff{};
-  std::vector<std::uint32_t> _start2_buff{};
-  std::vector<std::uint32_t> _end2_buff{};
+  std::vector<std::int32_t> _start2_buff{};
+  std::vector<std::int32_t> _end2_buff{};
 
   std::vector<N> _count_buff{};
 

--- a/test/units/transformers/transformers_to_dataframe_test.cpp
+++ b/test/units/transformers/transformers_to_dataframe_test.cpp
@@ -79,8 +79,10 @@ static void compare_pixel(const std::shared_ptr<arrow::Table>& table, const Thin
 
   REQUIRE(i < table->num_rows());
 
-  CHECK(internal::get_scalar<std::uint64_t>(table->GetColumnByName("bin1_id"), i) == p.bin1_id);
-  CHECK(internal::get_scalar<std::uint64_t>(table->GetColumnByName("bin2_id"), i) == p.bin2_id);
+  CHECK(internal::get_scalar<std::int64_t>(table->GetColumnByName("bin1_id"), i) ==
+        static_cast<std::int64_t>(p.bin1_id));
+  CHECK(internal::get_scalar<std::int64_t>(table->GetColumnByName("bin2_id"), i) ==
+        static_cast<std::int64_t>(p.bin2_id));
 
   CHECK(internal::get_scalar<N>(table->GetColumnByName("count"), i) == p.count);
 }
@@ -93,16 +95,16 @@ static void compare_pixel(const std::shared_ptr<arrow::Table>& table, const Pixe
 
   CHECK(internal::get_scalar<std::string>(table->GetColumnByName("chrom1"), i) ==
         p.coords.bin1.chrom().name());
-  CHECK(internal::get_scalar<std::uint32_t>(table->GetColumnByName("start1"), i) ==
-        p.coords.bin1.start());
-  CHECK(internal::get_scalar<std::uint32_t>(table->GetColumnByName("end1"), i) ==
-        p.coords.bin1.end());
+  CHECK(internal::get_scalar<std::int32_t>(table->GetColumnByName("start1"), i) ==
+        static_cast<std::int32_t>(p.coords.bin1.start()));
+  CHECK(internal::get_scalar<std::int32_t>(table->GetColumnByName("end1"), i) ==
+        static_cast<std::int32_t>(p.coords.bin1.end()));
   CHECK(internal::get_scalar<std::string>(table->GetColumnByName("chrom2"), i) ==
         p.coords.bin2.chrom().name());
-  CHECK(internal::get_scalar<std::uint32_t>(table->GetColumnByName("start2"), i) ==
-        p.coords.bin2.start());
-  CHECK(internal::get_scalar<std::uint32_t>(table->GetColumnByName("end2"), i) ==
-        p.coords.bin2.end());
+  CHECK(internal::get_scalar<std::int32_t>(table->GetColumnByName("start2"), i) ==
+        static_cast<std::int32_t>(p.coords.bin2.start()));
+  CHECK(internal::get_scalar<std::int32_t>(table->GetColumnByName("end2"), i) ==
+        static_cast<std::int32_t>(p.coords.bin2.end()));
   CHECK(internal::get_scalar<N>(table->GetColumnByName("count"), i) == p.count);
 }
 
@@ -118,8 +120,10 @@ namespace internal {
   const auto bin2_ids = data->GetColumnByName("bin2_id");
 
   for (std::int64_t i = 0; i < data->num_rows(); ++i) {
-    buff[static_cast<std::size_t>(i)].bin1_id = get_scalar<std::uint64_t>(bin1_ids, i);
-    buff[static_cast<std::size_t>(i)].bin2_id = get_scalar<std::uint64_t>(bin2_ids, i);
+    buff[static_cast<std::size_t>(i)].bin1_id =
+        static_cast<std::uint64_t>(get_scalar<std::int64_t>(bin1_ids, i));
+    buff[static_cast<std::size_t>(i)].bin2_id =
+        static_cast<std::uint64_t>(get_scalar<std::int64_t>(bin2_ids, i));
   }
   return buff;
 }
@@ -139,13 +143,14 @@ namespace internal {
   const auto end2 = data->GetColumnByName("end2");
 
   for (std::int64_t i = 0; i < data->num_rows(); ++i) {
-    buff[static_cast<std::size_t>(i)] = Pixel{chroms.at(get_scalar<std::string>(chrom1_ids, i)),
-                                              get_scalar<std::uint32_t>(start1, i),
-                                              get_scalar<std::uint32_t>(end1, i),
-                                              chroms.at(get_scalar<std::string>(chrom2_ids, i)),
-                                              get_scalar<std::uint32_t>(start2, i),
-                                              get_scalar<std::uint32_t>(end2, i),
-                                              std::uint8_t{}};
+    buff[static_cast<std::size_t>(i)] =
+        Pixel{chroms.at(get_scalar<std::string>(chrom1_ids, i)),
+              static_cast<std::uint32_t>(get_scalar<std::int32_t>(start1, i)),
+              static_cast<std::uint32_t>(get_scalar<std::int32_t>(end1, i)),
+              chroms.at(get_scalar<std::string>(chrom2_ids, i)),
+              static_cast<std::uint32_t>(get_scalar<std::int32_t>(start2, i)),
+              static_cast<std::uint32_t>(get_scalar<std::int32_t>(end2, i)),
+              std::uint8_t{}};
   }
   return buff;
 }


### PR DESCRIPTION
Using unsigned integers can lead to surprising results when using dataframes from scripting languages, where many users may not be aware of all the gotchas that comes with the wrap-around of uints.