### PR TITLE
[feature]: implement avail_normalizations() on multi-resolution files

### DIFF
--- a/docs/cpp_api/cooler.rst
+++ b/docs/cpp_api/cooler.rst
@@ -172,6 +172,7 @@ Multi-resolution Cooler (.mcool)
   .. cpp:function:: [[nodiscard]] auto chromosomes() const noexcept -> const Reference&;
   .. cpp:function:: [[nodiscard]] constexpr const std::vector<std::uint32_t>& resolutions() const noexcept;
   .. cpp:function:: [[nodiscard]] constexpr const MultiResAttributes& attributes() const noexcept;
+  .. cpp:funciton:: [[nodiscard]] const std::vector<balancing::Method>& avail_normalizations(std::string_view policy = "union") const;
 
   **Modifiers**
 

--- a/docs/cpp_api/generic.rst
+++ b/docs/cpp_api/generic.rst
@@ -71,7 +71,7 @@ File handle
   Calling any of these accessors does not involve any computation.
 
   .. cpp:function:: [[nodiscard]] bool has_normalization(std::string_view normalization) const;
-  .. cpp:function:: [[nodiscard]] std::vector<balancing::Method> avail_normalizations() const;
+  .. cpp:funciton:: [[nodiscard]] const std::vector<balancing::Method>& avail_normalizations(std::string_view policy = "union") const;
   .. cpp:function:: [[nodiscard]] const balancing::Weights &normalization(std::string_view normalization_) const;
   .. cpp:function:: [[nodiscard]] std::shared_ptr<const balancing::Weights> normalization_ptr(std::string_view normalization_) const;
 

--- a/src/libhictk/balancing/include/hictk/balancing/methods.hpp
+++ b/src/libhictk/balancing/include/hictk/balancing/methods.hpp
@@ -34,6 +34,12 @@ class Method {
   [[nodiscard]] friend bool operator!=(const Method &a, std::string_view b) { return !(a == b); }
   [[nodiscard]] friend bool operator!=(std::string_view a, const Method &b) { return !(a == b); }
 
+  [[nodiscard]] friend bool operator<(const Method &a, const Method &b) {
+    return a._name < b._name;
+  }
+  [[nodiscard]] friend bool operator<(const Method &a, std::string_view b) { return a._name < b; }
+  [[nodiscard]] friend bool operator<(std::string_view a, const Method &b) { return a < b._name; }
+
   [[nodiscard]] std::string_view to_string() const noexcept { return _name; }
 
   static Method NONE() { return Method{"NONE"}; }

--- a/src/libhictk/cooler/include/hictk/cooler/impl/multires_cooler_impl.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/impl/multires_cooler_impl.hpp
@@ -194,7 +194,7 @@ inline const std::vector<balancing::Method>& MultiResFile::avail_normalizations(
   }
 
   if (policy != "union" && policy != "intersection") {
-    throw std::invalid_argument("policy should be either \"union\" or \"intersection\"");
+    throw std::invalid_argument(R"(policy should be either "union" or "intersection")");
   }
 
   if (_resolutions.empty()) {

--- a/src/libhictk/cooler/include/hictk/cooler/multires_cooler.hpp
+++ b/src/libhictk/cooler/include/hictk/cooler/multires_cooler.hpp
@@ -38,6 +38,7 @@ class MultiResFile {
   std::vector<std::uint32_t> _resolutions{};
   MultiResAttributes _attrs{};
   Reference _chroms{};
+  mutable std::optional<std::pair<std::string, std::vector<balancing::Method>>> _normalizations{};
 
   MultiResFile(const HighFive::File& fp, Reference chroms, std::vector<std::uint32_t> resolutions,
                MultiResAttributes attrs);
@@ -64,6 +65,9 @@ class MultiResFile {
   [[nodiscard]] std::string path() const;
   [[nodiscard]] auto chromosomes() const noexcept -> const Reference&;
 
+  [[nodiscard]] const std::vector<balancing::Method>& avail_normalizations(
+      std::string_view policy = "union") const;
+
   [[nodiscard]] HighFive::File file_handle();
   [[nodiscard]] const HighFive::File& file_handle() const;
 
@@ -76,6 +80,9 @@ class MultiResFile {
  private:
   [[nodiscard]] static std::vector<std::uint32_t> read_resolutions(const HighFive::File& f);
   [[nodiscard]] static MultiResAttributes read_attributes(const HighFive::File& f);
+
+  [[nodiscard]] std::vector<balancing::Method> avail_normalizations_union() const;
+  [[nodiscard]] std::vector<balancing::Method> avail_normalizations_intersection() const;
 };
 
 }  // namespace hictk::cooler

--- a/src/libhictk/file/include/hictk/multires_file.hpp
+++ b/src/libhictk/file/include/hictk/multires_file.hpp
@@ -6,9 +6,13 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
+#include "hictk/balancing/methods.hpp"
 #include "hictk/cooler/multires_cooler.hpp"
 #include "hictk/file.hpp"
 #include "hictk/hic.hpp"
@@ -22,6 +26,7 @@ class MultiResFile {
   hic::MatrixUnit _unit{};
   Reference _chroms{};
   std::vector<std::uint32_t> _resolutions{};
+  mutable std::optional<std::pair<std::string, std::vector<balancing::Method>>> _normalizations{};
   std::string _format{};
   std::uint8_t _format_version{};
   BinTable::Type _bin_type{};
@@ -46,6 +51,8 @@ class MultiResFile {
   [[nodiscard]] constexpr BinTable::Type bin_type() const noexcept;
   [[nodiscard]] constexpr const std::vector<std::uint32_t>& resolutions() const noexcept;
   [[nodiscard]] const Reference& chromosomes() const noexcept;
+  [[nodiscard]] const std::vector<balancing::Method>& avail_normalizations(
+      std::string_view policy = "union") const;
 
   [[nodiscard]] File open(std::uint32_t resolution) const;
 };

--- a/src/libhictk/hic/include/hictk/hic/impl/utils_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/utils_impl.hpp
@@ -33,7 +33,7 @@ inline std::vector<balancing::Method> avail_normalizations_union(const std::file
   hic::internal::HiCFileReader reader(path.string());
 
   const auto& resolutions = reader.header().resolutions;
-  if (resolutions.size() == 0) {
+  if (resolutions.empty()) {
     return {};
   }
 
@@ -60,7 +60,7 @@ inline std::vector<balancing::Method> avail_normalizations_intersection(
   hic::internal::HiCFileReader reader(path.string());
 
   const auto& resolutions = reader.header().resolutions;
-  if (resolutions.size() == 0) {
+  if (resolutions.empty()) {
     return {};
   }
 
@@ -103,7 +103,7 @@ inline std::vector<balancing::Method> list_normalizations(const std::filesystem:
   if (policy == "intersection") {
     return internal::avail_normalizations_intersection(path, matrix_type, matrix_unit);
   }
-  throw std::invalid_argument("policy should be either \"union\" or \"intersection\"");
+  throw std::invalid_argument(R"(policy should be either "union" or "intersection")");
 }
 
 }  // namespace hictk::hic::utils

--- a/src/libhictk/hic/include/hictk/hic/impl/utils_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/utils_impl.hpp
@@ -4,11 +4,17 @@
 
 #pragma once
 
+#include <parallel_hashmap/phmap.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <filesystem>
+#include <stdexcept>
+#include <string_view>
 #include <vector>
 
+#include "hictk/balancing/methods.hpp"
+#include "hictk/hic/common.hpp"
 #include "hictk/hic/file_reader.hpp"
 
 namespace hictk::hic::utils {
@@ -19,4 +25,85 @@ inline std::vector<std::uint32_t> list_resolutions(const std::filesystem::path& 
   }
   return resolutions;
 }
+
+namespace internal {
+inline std::vector<balancing::Method> avail_normalizations_union(const std::filesystem::path& path,
+                                                                 MatrixType matrix_type,
+                                                                 MatrixUnit matrix_unit) {
+  hic::internal::HiCFileReader reader(path.string());
+
+  const auto& resolutions = reader.header().resolutions;
+  if (resolutions.size() == 0) {
+    return {};
+  }
+
+  if (resolutions.size() == 1) {
+    auto norms = reader.list_avail_normalizations(matrix_type, matrix_unit, resolutions.front());
+    std::sort(norms.begin(), norms.end());
+    return norms;
+  }
+
+  phmap::flat_hash_set<balancing::Method> norms;
+  for (const auto& res : resolutions) {
+    for (const auto& norm : reader.list_avail_normalizations(matrix_type, matrix_unit, res)) {
+      norms.emplace(norm);
+    }
+  }
+
+  std::vector norms_sorted(norms.begin(), norms.end());
+  std::sort(norms_sorted.begin(), norms_sorted.end());
+  return norms_sorted;
+}
+
+inline std::vector<balancing::Method> avail_normalizations_intersection(
+    const std::filesystem::path& path, MatrixType matrix_type, MatrixUnit matrix_unit) {
+  hic::internal::HiCFileReader reader(path.string());
+
+  const auto& resolutions = reader.header().resolutions;
+  if (resolutions.size() == 0) {
+    return {};
+  }
+
+  if (resolutions.size() == 1) {
+    auto norms = reader.list_avail_normalizations(matrix_type, matrix_unit, resolutions.front());
+    std::sort(norms.begin(), norms.end());
+    return norms;
+  }
+
+  phmap::flat_hash_map<balancing::Method, std::uint32_t> norms;
+  for (const auto& res : resolutions) {
+    for (const auto& norm : reader.list_avail_normalizations(matrix_type, matrix_unit, res)) {
+      auto [it, inserted] = norms.try_emplace(norm, std::uint32_t{1});
+      if (!inserted) {
+        it->second++;
+      }
+    }
+  }
+
+  std::vector<balancing::Method> filtered_norms{};
+  for (const auto& [norm, count] : norms) {
+    if (count == resolutions.size()) {
+      filtered_norms.emplace_back(norm);
+    }
+  }
+
+  std::sort(filtered_norms.begin(), filtered_norms.end());
+  return filtered_norms;
+}
+
+}  // namespace internal
+
+inline std::vector<balancing::Method> list_normalizations(const std::filesystem::path& path,
+                                                          std::string_view policy,
+                                                          MatrixType matrix_type,
+                                                          MatrixUnit matrix_unit) {
+  if (policy == "union") {
+    return internal::avail_normalizations_union(path, matrix_type, matrix_unit);
+  }
+  if (policy == "intersection") {
+    return internal::avail_normalizations_intersection(path, matrix_type, matrix_unit);
+  }
+  throw std::invalid_argument("policy should be either \"union\" or \"intersection\"");
+}
+
 }  // namespace hictk::hic::utils

--- a/src/libhictk/hic/include/hictk/hic/utils.hpp
+++ b/src/libhictk/hic/include/hictk/hic/utils.hpp
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <vector>
 
+#include "hictk/balancing/methods.hpp"
+#include "hictk/hic/common.hpp"
 #include "hictk/tmpdir.hpp"
 
 namespace hictk::hic::utils {
@@ -36,6 +38,10 @@ void merge(
 
 [[nodiscard]] std::vector<std::uint32_t> list_resolutions(const std::filesystem::path& path,
                                                           bool sorted = true);
+[[nodiscard]] std::vector<balancing::Method> list_normalizations(
+    const std::filesystem::path& path, std::string_view policy = "union",
+    MatrixType matrix_type = MatrixType::observed, MatrixUnit matrix_unit = MatrixUnit::BP);
+
 }  // namespace hictk::hic::utils
 
 #include "./impl/utils_impl.hpp"        // NOLINT

--- a/test/units/cooler/multires_cooler_test.cpp
+++ b/test/units/cooler/multires_cooler_test.cpp
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <vector>
 
+#include "hictk/balancing/methods.hpp"
 #include "hictk/chromosome.hpp"
 #include "hictk/common.hpp"
 #include "hictk/cooler/cooler.hpp"
@@ -113,6 +114,35 @@ TEST_CASE("MultiResCooler: create resolutions", "[cooler][short]") {
     CHECK_THROWS(mclr.create_resolution(base_resolution / 2));
     CHECK_THROWS(mclr.create_resolution(base_resolution + 1));
   }
+}
+
+TEST_CASE("MultiResCooler: normalizations", "[cooler][short]") {
+  const auto path = datadir / "cooler" / "multires_cooler_test_file.mcool";
+
+  const MultiResFile mclr{path.string()};
+
+  namespace balancing = hictk::balancing;
+
+  const std::vector expected_norms_union{balancing::Method{"weight1"},
+                                         balancing::Method{"weight2"}};
+  const std::vector expected_norms_intersection{balancing::Method{"weight1"}};
+
+  auto found_norms = mclr.avail_normalizations("union");
+  REQUIRE(expected_norms_union.size() == found_norms.size());
+  for (std::size_t i = 0; i < expected_norms_union.size(); ++i) {
+    CHECK(expected_norms_union[i] == found_norms[i]);
+  }
+
+  found_norms = mclr.avail_normalizations("intersection");
+  REQUIRE(expected_norms_intersection.size() == found_norms.size());
+  for (std::size_t i = 0; i < expected_norms_intersection.size(); ++i) {
+    CHECK(expected_norms_intersection[i] == found_norms[i]);
+  }
+
+  CHECK_THROWS_AS(mclr.avail_normalizations("invalid"), std::invalid_argument);
+
+  CHECK(&mclr.avail_normalizations("intersection") == &mclr.avail_normalizations("intersection"));
+  CHECK(&mclr.avail_normalizations("intersection") == &mclr.avail_normalizations("union"));
 }
 
 // NOLINTEND(*-avoid-magic-numbers, readability-function-cognitive-complexity)

--- a/test/units/file/multires_file_test.cpp
+++ b/test/units/file/multires_file_test.cpp
@@ -46,6 +46,7 @@ TEST_CASE("MultiResFile", "[file][short]") {
 
       CHECK(MultiResFile{path_hic}.resolutions().size() == 10);
       CHECK(MultiResFile{path_hic}.chromosomes().size() == 9);
+      CHECK(MultiResFile{path_hic}.avail_normalizations().size() == 4);
     }
     SECTION("mcool") {
       CHECK(MultiResFile{path_mcool}.is_mcool());
@@ -60,6 +61,7 @@ TEST_CASE("MultiResFile", "[file][short]") {
 
       CHECK(MultiResFile{path_mcool}.resolutions().size() == 10);
       CHECK(MultiResFile{path_mcool}.chromosomes().size() == 8);
+      CHECK(MultiResFile{path_mcool}.avail_normalizations().size() == 5);
     }
   }
 


### PR DESCRIPTION
These are for the most part convenience functions that allow taking the union or intersection of the normalizations available across all resolutions.