### PR TITLE
[feature]: improve automatic resolution inference

### DIFF
--- a/cmake/FetchTestDataset.cmake
+++ b/cmake/FetchTestDataset.cmake
@@ -8,8 +8,8 @@ endif()
 
 # gersemi: off
 file(
-  DOWNLOAD https://zenodo.org/records/15005955/files/hictk_test_data.tar.zst?download=1
-  EXPECTED_HASH SHA256=4e1ed0871b07c8724d3db635ba45850c1b97a2ee18dcee947d827ca5c5b4c1d2
+  DOWNLOAD https://zenodo.org/records/15012705/files/hictk_test_data.tar.zst?download=1
+  EXPECTED_HASH SHA256=d8114081f46eefdf8bea9655e9a6917c28bb46f641244cba2b60d9553d18c3dd
   "${PROJECT_SOURCE_DIR}/test/data/hictk_test_data.tar.zst"
 )
 # gersemi: on

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -239,7 +239,7 @@ hictk dump
   Options:
     -h,--help                   Print this help message and exit
     --resolution UINT:NONNEGATIVE
-                                HiC matrix resolution (ignored when file is in .cool format).
+                                HiC matrix resolution (required when processing multi-resolution files).
     --matrix-type ENUM:{observed,oe,expected} [observed]
                                 Matrix type (ignored when file is not in .hic format).
     --matrix-unit ENUM:{BP,FRAG} [BP]
@@ -377,8 +377,7 @@ hictk merge
                                 Should be one of:
                                 - cool
                                 - hic
-    --resolution UINT:NONNEGATIVE
-                                Hi-C matrix resolution (ignored when input files are in .cool format).
+    --resolution UINT:POSITIVE  Hi-C matrix resolution (required when all input files are multi-resolution).
     -f,--force                  Force overwrite output file.
     --chunk-size UINT [10000000]
                                 Number of pixels to store in memory before writing to disk.

--- a/docs/cpp_api/hic.rst
+++ b/docs/cpp_api/hic.rst
@@ -48,11 +48,11 @@ File handle
 
   **Constructors**
 
-  .. cpp:function:: explicit File(std::string url_, std::uint32_t resolution_, MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
+  .. cpp:function:: explicit File(std::string url_, std::optional<std::uint32_t> resolution_, MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
 
   **Open/close methods**
 
-  .. cpp:function:: File &open(std::string url_, std::uint32_t resolution_, MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
+  .. cpp:function:: File &open(std::string url_, std::optional<std::uint32_t> resolution_, MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
   .. cpp:function:: File &open(std::uint32_t resolution_, MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
 
   **Accessors**

--- a/src/hictk/cli/cli_convert.cpp
+++ b/src/hictk/cli/cli_convert.cpp
@@ -25,6 +25,7 @@
 #include "hictk/hic.hpp"
 #include "hictk/hic/utils.hpp"
 #include "hictk/hic/validation.hpp"
+#include "hictk/multires_file.hpp"
 #include "hictk/string_utils.hpp"
 #include "hictk/tmpdir.hpp"
 #include "hictk/tools/cli.hpp"
@@ -211,6 +212,13 @@ void Cli::validate_convert_subcommand() const {
       errors.emplace_back(fmt::format(
           FMT_STRING("converting .mcool with storage-mode=\"{}\" to .hic format is not supported"),
           *storage_mode));
+    }
+  } else if (is_hic && output_format == "cool") {
+    const auto input_is_multires = MultiResFile{c.path_to_input.string()}.resolutions().size() != 1;
+    if (c.resolutions.size() != 1 && input_is_multires) {
+      errors.emplace_back(
+          "converting multi-resolution .hic files to .cool format requires exactly one resolution "
+          "to be passed through the --resolutions option");
     }
   }
 

--- a/src/hictk/cli/cli_convert.cpp
+++ b/src/hictk/cli/cli_convert.cpp
@@ -176,6 +176,7 @@ static void check_requested_resolutions_avail(const std::filesystem::path& path_
   }
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void Cli::validate_convert_subcommand() const {
   const auto& c = std::get<ConvertConfig>(_config);
   std::vector<std::string> errors;

--- a/src/hictk/cli/cli_merge.cpp
+++ b/src/hictk/cli/cli_merge.cpp
@@ -223,6 +223,12 @@ void Cli::transform_args_merge_subcommand() {
 
   assert(c.resolution.has_value());
 
+  for (auto& f : c.input_files) {
+    if (cooler::utils::is_multires_file(f)) {
+      f.append(fmt::format(FMT_STRING("::/resolutions/{}"), *c.resolution));
+    }
+  }
+
   if (sc.get_option("--compression-lvl")->empty()) {
     c.compression_lvl =
         c.output_format == "hic" ? DEFAULT_HIC_COMPRESSION_LEVEL : DEFAULT_COOL_COMPRESSION_LEVEL;

--- a/src/hictk/cli/cli_merge.cpp
+++ b/src/hictk/cli/cli_merge.cpp
@@ -142,15 +142,18 @@ static void validate_resolution(const std::vector<std::string>& paths, std::uint
   assert(!paths.empty());
 
   for (const auto& p : paths) {
-    const auto format = infer_input_format(p);
-    assert(format != "scool");
+    assert(infer_input_format(p) != "scool");
 
     try {
       std::ignore = File{p, resolution};
     } catch (const std::exception& e) {
+      std::string_view msg{e.what()};
+      if (msg.find("found an unexpected resolution") == 0) {
+        msg = "please make sure all provided files have at least one resolution in common";
+      }
       errors.emplace_back(
           fmt::format(FMT_STRING("file \"{}\" does not have interactions for {} resolution: {}"), p,
-                      resolution, e.what()));
+                      resolution, msg));
     }
   }
 }

--- a/src/hictk/cli/cli_merge.cpp
+++ b/src/hictk/cli/cli_merge.cpp
@@ -180,9 +180,9 @@ static void validate_files_format(const std::vector<std::string>& paths,
         "unable to infer the resolution to use for merging: --resolution is mandatory when all "
         "input "
         "files are in .hic or .mcool format and contain multiple resolutions.");
+  } else {
+    validate_resolution(paths, *resolution, errors);
   }
-
-  validate_resolution(paths, *resolution, errors);
 }
 
 void Cli::validate_merge_subcommand() const {

--- a/src/hictk/cli/cli_merge.cpp
+++ b/src/hictk/cli/cli_merge.cpp
@@ -42,7 +42,7 @@ void Cli::make_merge_subcommand() {
       "input-files",
       c.input_files,
       "Path to two or more Cooler or .hic files to be merged (Cooler URI syntax supported).")
-      ->check(IsValidCoolerFile | IsValidHiCFile)
+      ->check(IsValidCoolerFile | IsValidMultiresCoolerFile | IsValidHiCFile)
       ->expected(2, std::numeric_limits<int>::max())
       ->required();
   sc.add_option(

--- a/src/hictk/convert/hic_to_cool.cpp
+++ b/src/hictk/convert/hic_to_cool.cpp
@@ -329,7 +329,8 @@ void hic_to_cool(const ConvertConfig& c) {  // NOLINT(misc-use-internal-linkage)
         hic::File hf(c.path_to_input.string(), c.resolutions.front());
         assert(spdlog::default_logger());
 
-        if (c.resolutions.size() == 1) {
+        if (c.output_format == "cool") {
+          assert(c.resolutions.size() == 1);
           convert_resolution_multi_threaded<PixelT>(
               hf,
               init_cooler<PixelT>(c.path_to_output.string(), c.resolutions.front(), c.genome,

--- a/src/hictk/include/hictk/tools/cli.hpp
+++ b/src/hictk/include/hictk/tools/cli.hpp
@@ -371,6 +371,9 @@ class Cli {
 };
 
 [[nodiscard]] inline std::string infer_input_format(const std::filesystem::path& p) {
+  if (hic::utils::is_hic_file(p)) {
+    return "hic";
+  }
   if (cooler::utils::is_cooler(p.string())) {
     return "cool";
   }
@@ -380,8 +383,9 @@ class Cli {
   if (cooler::utils::is_scool_file(p.string())) {
     return "scool";
   }
-  assert(hic::utils::is_hic_file(p));
-  return "hic";
+
+  throw std::runtime_error(
+      fmt::format(FMT_STRING("unable to infer file format for file \"{}\""), p.string()));
 }
 
 [[nodiscard]] inline std::string infer_output_format(const std::filesystem::path& p) {

--- a/src/hictk/include/hictk/tools/config.hpp
+++ b/src/hictk/include/hictk/tools/config.hpp
@@ -185,7 +185,7 @@ struct MergeConfig {
   std::vector<std::string> input_files{};
   std::filesystem::path output_file{};
   std::string output_format{};
-  std::uint32_t resolution{};
+  std::optional<std::uint32_t> resolution{};
 
   std::filesystem::path tmp_dir{};
 

--- a/src/hictk/merge/cool.cpp
+++ b/src/hictk/merge/cool.cpp
@@ -16,18 +16,20 @@ namespace hictk::tools {
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 void merge_to_cool(const MergeConfig& c) {
+  assert(c.resolution.has_value());
   constexpr std::size_t update_freq = 10'000'000;
-  SPDLOG_INFO(FMT_STRING("begin merging {} files into one .{} file..."), c.input_files.size(),
-              c.output_format);
+  SPDLOG_INFO(FMT_STRING("begin merging {} files into one .{} file using resolution {}..."),
+              c.input_files.size(), c.output_format, *c.resolution);
   if (c.count_type == "int") {
     utils::merge_to_cool<std::int32_t>(c.input_files.begin(), c.input_files.end(),
-                                       c.output_file.string(), c.resolution, c.force, c.chunk_size,
+                                       c.output_file.string(), *c.resolution, c.force, c.chunk_size,
                                        update_freq, c.compression_lvl);
     return;
   }
   assert(c.count_type == "float");
   utils::merge_to_cool<double>(c.input_files.begin(), c.input_files.end(), c.output_file.string(),
-                               c.resolution, c.force, c.chunk_size, update_freq, c.compression_lvl);
+                               *c.resolution, c.force, c.chunk_size, update_freq,
+                               c.compression_lvl);
 }
 
 }  // namespace hictk::tools

--- a/src/hictk/merge/hic.cpp
+++ b/src/hictk/merge/hic.cpp
@@ -5,6 +5,8 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
+#include <cassert>
+
 #include "./merge.hpp"
 #include "hictk/file.hpp"
 #include "hictk/tools/config.hpp"
@@ -13,10 +15,11 @@ namespace hictk::tools {
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 void merge_to_hic(const MergeConfig& c) {
-  SPDLOG_INFO(FMT_STRING("begin merging {} files into one .{} file..."), c.input_files.size(),
-              c.output_format);
+  assert(c.resolution.has_value());
+  SPDLOG_INFO(FMT_STRING("begin merging {} files into one .{} file using {} resolution..."),
+              c.input_files.size(), c.output_format, *c.resolution);
   utils::merge_to_hic(c.input_files.begin(), c.input_files.end(), c.output_file.string(),
-                      c.resolution, c.tmp_dir, c.force, c.chunk_size, c.threads, c.compression_lvl,
+                      *c.resolution, c.tmp_dir, c.force, c.chunk_size, c.threads, c.compression_lvl,
                       c.skip_all_vs_all_matrix);
 }
 

--- a/src/libhictk/hic/include/hictk/hic.hpp
+++ b/src/libhictk/hic/include/hictk/hic.hpp
@@ -41,11 +41,12 @@ class File {
 
  public:
   using QUERY_TYPE = GenomicInterval::Type;
-  explicit File(std::string url_, std::uint32_t resolution_,
+  explicit File(std::string url_, std::optional<std::uint32_t> resolution_ = {},
                 MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP,
                 std::uint64_t block_cache_capacity = 0);
-  File &open(std::string url_, std::uint32_t resolution_, MatrixType type_ = MatrixType::observed,
-             MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
+  File &open(std::string url_, std::optional<std::uint32_t> resolution_ = {},
+             MatrixType type_ = MatrixType::observed, MatrixUnit unit_ = MatrixUnit::BP,
+             std::uint64_t block_cache_capacity = 0);
   File &open(std::uint32_t resolution_, MatrixType type_ = MatrixType::observed,
              MatrixUnit unit_ = MatrixUnit::BP, std::uint64_t block_cache_capacity = 0);
   [[nodiscard]] bool has_resolution(std::uint32_t resolution) const;
@@ -142,6 +143,8 @@ class File {
                                     std::optional<std::uint64_t> diagonal_band_width) const;
   [[nodiscard]] std::size_t estimate_cache_size_cis() const;
   [[nodiscard]] std::size_t estimate_cache_size_trans() const;
+  [[nodiscard]] static std::uint32_t infer_or_validate_resolution(
+      const internal::HiCFileReader &fs, std::optional<std::uint32_t> wanted_resolution);
 };
 
 }  // namespace hictk::hic

--- a/test/integration/config.toml
+++ b/test/integration/config.toml
@@ -167,6 +167,8 @@ output-names = [
 [merge]
 
 files = [
+  { uri = "cooler/4DNFIZ1ZVXC8.mcool", format = "mcool" },
+  { uri = "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/2500000", format = "mcool" },
   { uri = "cooler/cooler_test_file.cool", format = "cool" },
   { uri = "cooler/ENCFF993FGR.2500000.cool", format = "cool" },
   { uri = "cooler/multires_cooler_test_file.mcool::/resolutions/100000", format = "cool" },
@@ -187,7 +189,7 @@ test-cases = [
   { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.hic", args = { "resolution" = 2500000 } },
   { input-uris = ["hic/ENCFF993FGR.2500000.hic", "cooler/ENCFF993FGR.2500000.cool"], output = "test.hic", args = { "resolution" = 2500000 } },
   { input-uris = ["cooler/cooler_test_file.cool", "cooler/multires_cooler_test_file.mcool::/resolutions/99999"], output = "test.cool", expect-failure = true },
-  { input-uris = ["cooler/cooler_test_file.cool", "cooler/multires_cooler_test_file.mcool"], output = "test.cool", expect-failure = true },
+  { input-uris = ["cooler/cooler_test_file.cool", "cooler/multires_cooler_test_file.mcool"], output = "test.cool" },
   { input-uris = ["cooler/cooler_test_file.cool", "cooler/cooler_variable_bins_test_file.cool"], output = "test.cool", expect-failure = true },
   { input-uris = ["cooler/multires_cooler_test_file.mcool", "cooler/multires_cooler_test_file.mcool"], output = "test.cool", expect-failure = true },
   { input-uris = ["cooler/single_cell_cooler_test_file.scool", "cooler/single_cell_cooler_test_file.scool"], output = "test.scool", expect-failure = true },
@@ -197,6 +199,9 @@ test-cases = [
   { input-uris = ["cooler/single_cell_cooler_test_file.scool", "hic/4DNFIZ1ZVXC8.hic9"], output = "test.cool", expect-failure = true },
   { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.hic" },
   { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.cool" },
+  { input-uris = ["hic/4DNFIZ1ZVXC8.hic9", "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/2500000"], output = "test.hic" },
+  { input-uris = ["hic/4DNFIZ1ZVXC8.hic9", "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/2500000"], output = "test.cool" },
+  { input-uris = ["cooler/4DNFIZ1ZVXC8.mcool", "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/2500000"], output = "test.cool" },
 ]
 
 

--- a/test/integration/config.toml
+++ b/test/integration/config.toml
@@ -195,7 +195,8 @@ test-cases = [
   { input-uris = ["cooler/cooler_test_file.cool", "hic/4DNFIZ1ZVXC8.hic9"], output = "test.cool", expect-failure = true },
   { input-uris = ["cooler/multires_cooler_test_file.mcool", "hic/4DNFIZ1ZVXC8.hic9"], output = "test.cool", expect-failure = true },
   { input-uris = ["cooler/single_cell_cooler_test_file.scool", "hic/4DNFIZ1ZVXC8.hic9"], output = "test.cool", expect-failure = true },
-  { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.hic", expect-failure = true }
+  { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.hic" },
+  { input-uris = ["cooler/ENCFF993FGR.2500000.cool", "hic/ENCFF993FGR.2500000.hic"], output = "test.cool" },
 ]
 
 

--- a/test/integration/config.toml
+++ b/test/integration/config.toml
@@ -71,11 +71,13 @@ files = [
   { uri = "cooler/multires_cooler_test_file.mcool::/resolutions/100000", format = "cool" },
   { uri = "cooler/single_cell_cooler_test_file.scool::/cells/GSM2687248_41669_ACAGTG-R1-DpnII.100000.cool", format = "cool" },
   { uri = "cooler/multires_cooler_test_file.mcool", format = "mcool" },
+  { uri = "cooler/singleres_cooler_test_file.mcool", format = "mcool" },
   { uri = "cooler/single_cell_cooler_test_file.scool", format = "scool" },
   { uri = "cooler/cooler_variable_bins_test_file.cool", format = "cool", variable-bin-size = true },
   { uri = "cooler/cooler_storage_mode_square_test_file.mcool::/resolutions/1000", format = "cool" },
   { uri = "hic/4DNFIZ1ZVXC8.hic8", format = "hic", reference-uri = "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/100000", resolution = 100000, excluded-norms = ["KR", "ICE", "weight"] },
   { uri = "hic/4DNFIZ1ZVXC8.hic9", format = "hic", reference-uri = "cooler/4DNFIZ1ZVXC8.mcool::/resolutions/100000", resolution = 100000, excluded-norms = ["KR", "SCALE", "ICE", "weight"] },
+  { uri = "hic/ENCFF993FGR.2500000.hic", format = "hic", reference-uri = "cooler/ENCFF993FGR.2500000.cool", excluded-norms = ["weight"] },
 ]
 
 queries = [
@@ -83,13 +85,15 @@ queries = [
   { uri = "cooler/multires_cooler_test_file.mcool::/resolutions/100000", range1 = "1", range2 = "X" },
   { uri = "cooler/single_cell_cooler_test_file.scool::/cells/GSM2687248_41669_ACAGTG-R1-DpnII.100000.cool", range1 = "1", range2 = "X" },
   { uri = "cooler/multires_cooler_test_file.mcool", range1 = "1", range2 = "X" },
+  { uri = "cooler/singleres_cooler_test_file.mcool", range1 = "1", range2 = "X", expect-failure = false },
   { uri = "cooler/single_cell_cooler_test_file.scool", range1 = "1", range2 = "X" },
   { uri = "cooler/cooler_variable_bins_test_file.cool", range1 = "chr1", range2 = "chr2" },
   { uri = "cooler/cooler_storage_mode_square_test_file.mcool::/resolutions/1000", range1 = "", range2 = "", expect-failure = false },
   { uri = "cooler/cooler_storage_mode_square_test_file.mcool::/resolutions/1000", range1 = "chr1", range2 = "chr2", expect-failure = true },
   { uri = "cooler/ENCFF993FGR.2500000.cool", range1 = "chr1", range2 = "chrX", normalization = "VC" },
   { uri = "hic/4DNFIZ1ZVXC8.hic8", range1 = "chr2L", range2 = "chrX", normalization = "VC" },
-  { uri = "hic/4DNFIZ1ZVXC8.hic9", range1 = "chr2L", range2 = "chrX", normalization = "VC" }
+  { uri = "hic/4DNFIZ1ZVXC8.hic9", range1 = "chr2L", range2 = "chrX", normalization = "VC" },
+  { uri = "hic/ENCFF993FGR.2500000.hic", range1 = "chr1", range2 = "chrX", normalization = "VC", expect-failure = false },
 ]
 
 

--- a/test/integration/src/hictk_integration_suite/cli/dump.py
+++ b/test/integration/src/hictk_integration_suite/cli/dump.py
@@ -28,16 +28,18 @@ def _extract_queries_for_uri(
         if not file.endswith(os.path.basename(c["uri"])):
             continue
 
-        queries.append(
-            {
-                "uri": str(uri),
-                "reference-uri": str(reference_uri),
-                "resolution": resolution,
-                "range1": c.get("range1"),
-                "range2": c.get("range2"),
-                "normalization": c.get("normalization"),
-            }
-        )
+        query = {
+            "uri": str(uri),
+            "reference-uri": str(reference_uri),
+            "resolution": resolution,
+            "range1": c.get("range1"),
+            "range2": c.get("range2"),
+            "normalization": c.get("normalization"),
+        }
+        if "expect-failure" in c:
+            query["expect-failure"] = c["expect-failure"]
+
+        queries.append(query)
 
     return queries
 
@@ -124,6 +126,9 @@ def _plan_tests_hictk_dump_bins(
         factory["expect_failure"] = is_multires(uri) and resolution is None
         for query in _extract_queries_for_uri(uri, reference_uri, resolution, cell, config):
             assert query.get("range1") is not None
+
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
 
             # hictk dump ... -t bins
             query_gw = _make_hictk_dump_args(
@@ -231,6 +236,9 @@ def _plan_tests_hictk_dump_norms(
         reference_uri = wd[c.get("reference-uri", c["uri"])]
         excluded_norms = tuple(c.get("excluded-norms", []))
         for query in _extract_queries_for_uri(uri, reference_uri, c.get("resolution"), c.get("cell"), config):
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
+
             # hictk dump ... -t normalizations
             args = _make_hictk_dump_args(
                 query,
@@ -265,6 +273,9 @@ def _plan_tests_hictk_dump_resolutions(
         uri = wd[c["uri"]]
         reference_uri = wd[c.get("reference-uri", c["uri"])]
         for query in _extract_queries_for_uri(uri, reference_uri, c.get("resolution"), c.get("cell"), config):
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
+
             # hictk dump ... -t resolutions
             args = _make_hictk_dump_args(
                 query,
@@ -333,6 +344,9 @@ def _plan_tests_hictk_dump_weights(
             assert query.get("range1") is not None
             assert query.get("range2") is not None
 
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
+
             # hictk dump ... -t weights
             args1 = _make_hictk_dump_args(
                 query,
@@ -379,6 +393,9 @@ def _plan_tests_hictk_dump_cis(
         factory["expect_failure"] = (is_multires(uri) and c.get("resolution") is None) or is_scool(uri)
         for query in _extract_queries_for_uri(uri, reference_uri, c.get("resolution"), c.get("cell"), config):
             assert query.get("range1") is not None
+
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
 
             # hictk dump ... --range xxx
             query_raw_coo = _make_hictk_dump_args(query, drop_args={"range2", "normalization"})
@@ -482,6 +499,9 @@ def _plan_tests_hictk_dump_trans(
             assert query.get("range1") is not None
             assert query.get("range2") is not None
 
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
+
             # hictk dump ... --range xxx --range2 xxx
             query_raw_coo = _make_hictk_dump_args(query, drop_args={"normalization"})
             # hictk dump ... --range xxx --range2 xxx --normalization xxx
@@ -582,6 +602,9 @@ def _plan_tests_hictk_dump_gw(
         for query in _extract_queries_for_uri(uri, reference_uri, c.get("resolution"), c.get("cell"), config):
             assert query.get("range1") is not None
             assert query.get("range2") is not None
+
+            if "expect-failure" in query:
+                factory["expect_failure"] = query["expect-failure"]
 
             # hictk dump ...
             query_raw_coo = _make_hictk_dump_args(query, drop_args={"range1", "range2", "normalization"})

--- a/test/integration/src/hictk_integration_suite/runners/cooler/dump.py
+++ b/test/integration/src/hictk_integration_suite/runners/cooler/dump.py
@@ -41,8 +41,15 @@ class CoolerDump:
             if resolution is not None:
                 assert clr.binsize == resolution
             return clr
-        if is_multires(uri) and resolution is not None:
-            return cooler.Cooler(f"{uri}::/resolutions/{resolution}")
+
+        if is_multires(uri):
+            if resolution is not None:
+                return cooler.Cooler(f"{uri}::/resolutions/{resolution}")
+
+            suffixes = cooler.fileops.list_coolers(uri)
+            if len(suffixes) == 1:
+                return cooler.Cooler(f"{uri}::{suffixes[0]}")
+
         return None
 
     def _fetch_gw_pixels(self, balance: str | bool, join: bool) -> pd.DataFrame | None:

--- a/test/integration/src/hictk_integration_suite/runners/hictkpy/dump.py
+++ b/test/integration/src/hictk_integration_suite/runners/hictkpy/dump.py
@@ -37,7 +37,10 @@ class HictkpyDump:
         uri: str, resolution: int | None
     ) -> hictkpy.File | hictkpy.MultiResFile | hictkpy.cooler.SingleCellFile | None:
         if is_multires(uri) and resolution is None:
-            return hictkpy.MultiResFile(uri)
+            f = hictkpy.MultiResFile(uri)
+            if len(f.resolutions()) == 1:
+                return f[f.resolutions()[0]]
+            return f
 
         if is_scool(uri):
             f = hictkpy.cooler.SingleCellFile(uri)

--- a/test/units/file/file_test.cpp
+++ b/test/units/file/file_test.cpp
@@ -36,25 +36,35 @@ TEST_CASE("File", "[file][short]") {
   const cooler::File ref(uri_cooler);
 
   SECTION("ctors") {
-    CHECK(File(path_hic, resolution).path() == path_hic);
-    CHECK(File(path_cooler, resolution).path() == path_cooler);
-    CHECK(File(uri_cooler).uri() == uri_cooler);
+    const auto path_singleres_hic = (datadir / "hic" / "ENCFF993FGR.2500000.hic").string();
+    const auto path_singleres_mcool =
+        (datadir / "cooler" / "singleres_cooler_test_file.mcool").string();
+    SECTION("valid") {
+      CHECK(File(path_hic, resolution).path() == path_hic);
+      CHECK(File(path_cooler, resolution).path() == path_cooler);
+      CHECK(File(uri_cooler).uri() == uri_cooler);
+      CHECK(File(path_singleres_hic).resolution() == 2'500'000);
+      CHECK(File(path_singleres_mcool).resolution() == 6'400'000);
+    }
 
-    // Invalid params for .mcool files
-    CHECK_THROWS_WITH(File(path_cooler),
-                      Catch::Matchers::ContainsSubstring("resolution is required"));
-    CHECK_THROWS_WITH(File(path_cooler, resolution, hic::MatrixType::expected),
-                      Catch::Matchers::ContainsSubstring("should always be \"observed\""));
-    CHECK_THROWS_WITH(
-        File(path_cooler, resolution, hic::MatrixType::observed, hic::MatrixUnit::FRAG),
-        Catch::Matchers::ContainsSubstring("should always be \"BP\""));
+    SECTION("invalid") {
+      // Invalid params for .mcool files
+      CHECK_THROWS_WITH(File(path_cooler),
+                        Catch::Matchers::ContainsSubstring("resolution is required"));
+      CHECK_THROWS_WITH(File(path_cooler, resolution, hic::MatrixType::expected),
+                        Catch::Matchers::ContainsSubstring("should always be \"observed\""));
+      CHECK_THROWS_WITH(
+          File(path_cooler, resolution, hic::MatrixType::observed, hic::MatrixUnit::FRAG),
+          Catch::Matchers::ContainsSubstring("should always be \"BP\""));
 
-    // Invalid params for .hic files
-    CHECK_THROWS_WITH(File(path_hic), Catch::Matchers::ContainsSubstring("resolution is required"));
+      // Invalid params for .hic files
+      CHECK_THROWS_WITH(File(path_hic),
+                        Catch::Matchers::ContainsSubstring("resolution is required"));
 
-    // Mismatched resolution
-    CHECK_THROWS_WITH(File(uri_cooler, resolution + 1),
-                      Catch::Matchers::ContainsSubstring("found an unexpected resolution"));
+      // Mismatched resolution
+      CHECK_THROWS_WITH(File(uri_cooler, resolution + 1),
+                        Catch::Matchers::ContainsSubstring("found an unexpected resolution"));
+    }
   }
 
   SECTION("accessors") {

--- a/test/units/hic/hic_file_test.cpp
+++ b/test/units/hic/hic_file_test.cpp
@@ -28,6 +28,7 @@ static const auto& datadir = hictk::test::datadir;
 // NOLINTBEGIN(*-avoid-magic-numbers, readability-function-cognitive-complexity)
 
 // NOLINTBEGIN(cert-err58-cpp)
+const auto single_res = (datadir / "hic" / "ENCFF993FGR.2500000.hic").string();
 const auto pathV8 = (datadir / "hic" / "4DNFIZ1ZVXC8.hic8").string();
 const auto pathV9 = (datadir / "hic" / "4DNFIZ1ZVXC8.hic9").string();
 const auto path_binary = (datadir / "various" / "data.zip").string();
@@ -36,6 +37,19 @@ const auto path_binary = (datadir / "various" / "data.zip").string();
 TEST_CASE("HiC: utils is_hic_file", "[hic][short]") {
   CHECK(utils::is_hic_file(pathV8));
   CHECK_FALSE(utils::is_hic_file(path_binary));
+}
+
+TEST_CASE("HiC: ctors", "[hic][short]") {
+  SECTION("valid") {
+    CHECK_NOTHROW(File{pathV8, 1'000});
+    CHECK_NOTHROW(File{pathV9, 1'000});
+    CHECK(File{single_res}.resolution() == 2'500'000);
+  }
+  SECTION("invalid") {
+    CHECK_THROWS_WITH(File(pathV8, 1), Catch::Matchers::ContainsSubstring(
+                                           "does not have interactions for resolution"));
+    CHECK_THROWS_WITH(File(pathV8), Catch::Matchers::ContainsSubstring("resolution is required"));
+  }
 }
 
 TEST_CASE("HiC: file accessors", "[hic][short]") {


### PR DESCRIPTION
On the library side, hictk will now transparently handle single-resolution .mcool and .hic files.
The only case where this is not supported is when opening files directly with `cooler::File()`.

On the CLI, this means that specifying `--resolution(s)` is required in fewer cases when calling`hictk convert/dump/merge` on `.mcool` and `.hic` files.