### PR TITLE
[feature]: make sure all well-behaved errors result in exit code 1

### DIFF
--- a/src/hictk/cli/cli.cpp
+++ b/src/hictk/cli/cli.cpp
@@ -63,7 +63,7 @@ auto Cli::parse_arguments() -> Config {
     }
   } catch (const CLI::ParseError& e) {
     //  This takes care of formatting and printing error messages (if any)
-    _exit_code = _cli.exit(e);
+    _exit_code = exit(e);
     return _config;
   } catch (const std::exception& e) {
     _exit_code = 1;
@@ -86,7 +86,7 @@ auto Cli::parse_arguments() -> Config {
   return _config;
 }
 
-int Cli::exit(const CLI::ParseError& e) const { return _cli.exit(e); }
+int Cli::exit(const CLI::ParseError& e) const { return _cli.exit(e) != 0; }  // NOLINT
 int Cli::exit() const noexcept { return _exit_code; }
 
 std::string_view Cli::subcommand_to_str(subcommand s) noexcept {

--- a/src/hictk/main.cpp
+++ b/src/hictk/main.cpp
@@ -240,6 +240,14 @@ static std::tuple<int, Cli::subcommand, Config> parse_cli_and_setup_logger(Cli &
   }
 }
 
+[[nodiscard]] static std::string generate_command_name(const std::unique_ptr<Cli> &cli) {
+  if (cli) {
+    return fmt::format(FMT_STRING("hictk {}"), cli->get_printable_subcommand());
+  }
+
+  return "hictk";
+}
+
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char **argv) noexcept {
   std::unique_ptr<Cli> cli{nullptr};
@@ -295,29 +303,29 @@ int main(int argc, char **argv) noexcept {
             "If you see this message, please file an issue on GitHub");
     }
   } catch (const CLI::ParseError &e) {
-    assert(cli);
-    return cli->exit(e);  //  This takes care of formatting and printing error messages (if any)
-  } catch (const std::bad_alloc &err) {
-    SPDLOG_CRITICAL(FMT_STRING("FAILURE! Unable to allocate enough memory: {}"), err.what());
+    if (cli) {
+      //  This takes care of formatting and printing error messages (if any)
+      return cli->exit(e);
+    }
+    SPDLOG_CRITICAL("FAILURE! An unknown error occurred while parsing CLI arguments.");
+    return 1;
+  } catch (const std::bad_alloc &e) {
+    SPDLOG_CRITICAL(FMT_STRING("FAILURE! Unable to allocate enough memory: {}"), e.what());
     return 1;
   } catch (const spdlog::spdlog_ex &e) {
     fmt::print(stderr,
-               FMT_STRING("FAILURE! hictk encountered the following error while logging: {}\n"),
-               e.what());
+               FMT_STRING("FAILURE! {} encountered the following error while logging: {}\n"),
+               generate_command_name(cli), e.what());
     return 1;
   } catch (const std::exception &e) {
-    if (cli) {
-      SPDLOG_CRITICAL(FMT_STRING("FAILURE! hictk {} encountered the following error: {}"),
-                      cli->get_printable_subcommand(), e.what());
-    } else {
-      SPDLOG_CRITICAL(FMT_STRING("FAILURE! hictk encountered the following error: {}"), e.what());
-    }
+    SPDLOG_CRITICAL(FMT_STRING("FAILURE! {} encountered the following error: {}"),
+                    generate_command_name(cli), e.what());
     return 1;
   } catch (...) {
-    SPDLOG_CRITICAL(FMT_STRING("FAILURE! hictk {} encountered the following error: Caught an "
-                               "unhandled exception! "
-                               "If you see this message, please file an issue on GitHub."),
-                    cli->get_printable_subcommand());
+    SPDLOG_CRITICAL(
+        FMT_STRING("FAILURE! {} encountered the following error: Caught an unhandled exception! If "
+                   "you see this message, please file an issue on GitHub."),
+        generate_command_name(cli));
     return 1;
   }
   return 0;


### PR DESCRIPTION
This only affects the CLI tools.
Previously, errors due to invalid CLI arguments could lead to non-zero exit codes with platform-dependent values.