### PR TITLE
[bug]: fix segfault when fetching genome-wide interactions from empty .hic files

### DIFF
--- a/cmake/FetchTestDataset.cmake
+++ b/cmake/FetchTestDataset.cmake
@@ -12,8 +12,8 @@ message(STATUS "Fetching the test dataset")
 
 # gersemi: off
 file(
-  DOWNLOAD https://zenodo.org/records/15068509/files/hictk_test_data.tar.zst?download=1
-  EXPECTED_HASH SHA256=85960cc4088c8bdf6122f9c6660cefcf189e0fb050e30090988ae719c9ddb19f
+  DOWNLOAD https://zenodo.org/records/15182021/files/hictk_test_data.tar.zst?download=1
+  EXPECTED_HASH SHA256=7734a78307885e549ca64828a497a2c524e47acb92453e42532409ec7fb4e98a
   "${TEST_DATASET_TAR}"
 )
 # gersemi: on

--- a/src/hictk/convert/hic_to_cool.cpp
+++ b/src/hictk/convert/hic_to_cool.cpp
@@ -137,6 +137,10 @@ static Reference generate_reference(const std::filesystem::path& p, std::uint32_
     }
   }
 
+  if (selectors.empty()) {
+    return hic::PixelSelectorAll{hf.bins_ptr()};
+  }
+
   return hic::PixelSelectorAll{std::move(selectors)};
 }
 

--- a/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/hic_file_impl.hpp
@@ -179,7 +179,7 @@ inline PixelSelectorAll File::fetch(const balancing::Method& norm,
   }
 
   if (file_is_empty) {
-    return PixelSelectorAll{{}, _weight_cache};
+    return PixelSelectorAll{bins_ptr(), _weight_cache};
   }
 
   if (selectors.empty()) {

--- a/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
@@ -227,7 +227,8 @@ inline const balancing::Method &PixelSelector::normalization() const noexcept {
 }
 inline MatrixUnit PixelSelector::unit() const noexcept { return _reader->index().unit(); }
 inline std::uint32_t PixelSelector::resolution() const noexcept {
-  return _reader->index().resolution();
+  assert(_footer);
+  return _footer->resolution();
 }
 
 inline const Chromosome &PixelSelector::chrom1() const noexcept { return _coord1->bin1.chrom(); }

--- a/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
+++ b/src/libhictk/hic/include/hictk/hic/impl/pixel_selector_impl.hpp
@@ -758,12 +758,23 @@ PixelSelector::iterator<N>::preload_block_index(const PixelSelector &sel,
       idx.find_overlaps(sel.coord1(), sel.coord2(), diagonal_band_width));
 }
 
-inline PixelSelectorAll::PixelSelectorAll(
-    std::vector<PixelSelector> selectors_,
-    std::shared_ptr<internal::WeightCache> weight_cache) noexcept
+inline PixelSelectorAll::PixelSelectorAll(std::vector<PixelSelector> selectors_,
+                                          std::shared_ptr<internal::WeightCache> weight_cache)
     : _selectors(std::move(selectors_)),
       _bins(_selectors.empty() ? nullptr : _selectors.front().bins_ptr()),
-      _weight_cache(std::move(weight_cache)) {}
+      _weight_cache(std::move(weight_cache)) {
+  if (_selectors.empty()) {
+    throw std::invalid_argument(
+        "selectors_ cannot be empty! You may want to call a different constructor.");
+  }
+
+  assert(!!_bins);
+}
+
+inline PixelSelectorAll::PixelSelectorAll(
+    std::shared_ptr<const BinTable> bins_,
+    std::shared_ptr<internal::WeightCache> weight_cache) noexcept
+    : _bins(std::move(bins_)), _weight_cache(std::move(weight_cache)) {}
 
 inline bool PixelSelectorAll::empty() const noexcept { return begin<float>() == end<float>(); }
 
@@ -812,9 +823,7 @@ inline const balancing::Method &PixelSelectorAll::normalization() const noexcept
   return _selectors.front().normalization();
 }
 inline MatrixUnit PixelSelectorAll::unit() const noexcept { return _selectors.front().unit(); }
-inline std::uint32_t PixelSelectorAll::resolution() const noexcept {
-  return _selectors.front().resolution();
-}
+inline std::uint32_t PixelSelectorAll::resolution() const noexcept { return bins().resolution(); }
 
 inline const BinTable &PixelSelectorAll::bins() const noexcept {
   assert(_bins);

--- a/src/libhictk/hic/include/hictk/hic/pixel_selector.hpp
+++ b/src/libhictk/hic/include/hictk/hic/pixel_selector.hpp
@@ -208,6 +208,8 @@ class PixelSelectorAll {
  public:
   PixelSelectorAll() = default;
   explicit PixelSelectorAll(std::vector<PixelSelector> selectors_,
+                            std::shared_ptr<internal::WeightCache> weight_cache = nullptr);
+  explicit PixelSelectorAll(std::shared_ptr<const BinTable> bins_,
                             std::shared_ptr<internal::WeightCache> weight_cache = nullptr) noexcept;
 
   [[nodiscard]] bool empty() const noexcept;

--- a/test/units/hic/pixel_selector_test.cpp
+++ b/test/units/hic/pixel_selector_test.cpp
@@ -36,6 +36,7 @@ template <typename N>
 using Pixel = hictk::Pixel<N>;
 
 // NOLINTBEGIN(cert-err58-cpp)
+const auto path_empty = (datadir / "hic" / "empty_file.hic").string();
 const auto pathV8 = (datadir / "hic" / "4DNFIZ1ZVXC8.hic8").string();
 const auto pathV9 = (datadir / "hic" / "4DNFIZ1ZVXC8.hic9").string();
 const auto path_binary = (datadir / "various" / "data.zip").string();
@@ -107,6 +108,32 @@ TEST_CASE("HiC: pixel selector accessors", "[hic][short]") {
   CHECK(sel.resolution() == 2500000);
 
   REQUIRE(sel.chrom1().size() == 23513712);
+}
+
+TEST_CASE("HiC: pixel selector fetch (empty file)", "[hic][short]") {
+  const File hf(path_empty, 10);
+  CHECK(hf.resolution() == 10);
+
+  SECTION("cis") {
+    const auto sel = hf.fetch("chr1");
+    CHECK(sel.begin<float>() == sel.end<float>());
+    CHECK(sel.resolution() == 10);
+    CHECK(sel.bins().size() == 15);
+  }
+
+  SECTION("trans") {
+    const auto sel = hf.fetch("chr1", "chr2");
+    CHECK(sel.begin<float>() == sel.end<float>());
+    CHECK(sel.resolution() == 10);
+    CHECK(sel.bins().size() == 15);
+  }
+
+  SECTION("gw") {
+    const auto sel = hf.fetch();
+    CHECK(sel.begin<float>() == sel.end<float>());
+    CHECK(sel.resolution() == 10);
+    CHECK(sel.bins().size() == 15);
+  }
 }
 
 TEST_CASE("HiC: pixel selector fetch (observed NONE BP 10000)", "[hic][long]") {


### PR DESCRIPTION
This bug never occurred before because prior to hictk v2.1.0 (as far as I am aware) it was not possible to create well-formed .hic files with no interactions.