### PR TITLE
[ci]: make build-conan-deps-* workflows more reliable

### DIFF
--- a/.github/workflows/build-conan-deps-linux.yml
+++ b/.github/workflows/build-conan-deps-linux.yml
@@ -9,15 +9,6 @@ on:
       conan-key:
         description: "Conan packages"
         value: ${{ jobs.build-deps.outputs.conan-key }}
-      cmake-prefix-debug-key:
-        description: "CMake config dir (Debug)"
-        value: ${{ jobs.build-deps.outputs.cmake-dbg-key }}
-      cmake-prefix-release-key:
-        description: "CMake config dir (Release)"
-        value: ${{ jobs.build-deps.outputs.cmake-rel-key }}
-      cmake-prefix-relwithdebinfo-key:
-        description: "CMake config dir (RelWithDebInfo)"
-        value: ${{ jobs.build-deps.outputs.cmake-rwdi-key }}
 
     inputs:
       conan-version:
@@ -48,9 +39,6 @@ jobs:
     name: Build dependencies with Conan (Linux)
     runs-on: ubuntu-latest
 
-    permissions:
-      actions: write
-
     container:
       image: ${{ inputs.image }}
       options: "--user=root"
@@ -62,9 +50,6 @@ jobs:
 
     outputs:
       conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
-      cmake-dbg-key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-      cmake-rel-key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-      cmake-rwdi-key: ${{ steps.generate-cache-key.outputs.cmake-rwdi-key }}
 
     steps:
       - name: Checkout conanfile.py
@@ -88,43 +73,32 @@ jobs:
           suffix="$(echo "$suffix" | tr -c '[:alnum:]._-' '-' | sed 's/-\+/-/g' | sed 's/-$//')"
 
           echo "conan-key=conan-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-dbg-key=cmake-dbg-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-rel-key=cmake-rel-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-rwdi-key=cmake-rwdi-$suffix" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Restore CMake configs (Debug) cache
-        id: cache-cmake-dbg
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-          lookup-only: true
-
-      - name: Restore CMake configs (Release) cache
-        id: cache-cmake-rel
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: /tmp/cmake-prefix-rel.tar
-          lookup-only: true
-
-      - name: Restore CMake configs (RelWithDebInfo) cache
-        id: cache-cmake-rwdi
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rwdi-key }}
-          path: /tmp/cmake-prefix-rwdi.tar
-          lookup-only: true
-
-      - name: Restore package cache
-        id: cache-conan
+      - name: Lookup package cache
+        id: lookup-conan-cache
         uses: actions/cache/restore@v4
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
+          lookup-only: true
+
+      - name: Restore package cache
+        uses: actions/cache/restore@v4
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
 
       - name: Clean Conan cache (pre-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -132,7 +106,7 @@ jobs:
           conan remove --confirm "*"
 
       - name: Install build dependencies
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           apt-get update
           apt-get install -y -q gcc g++
@@ -146,11 +120,7 @@ jobs:
              -pr:h=gcc
 
       - name: Tweak conan profile
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true'      ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'  ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'  ||
-          steps.cache-cmake-rwdi.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           # Newer versions of b2 lead to exceptions like
           # ConanException: These libraries were built, but were not used in any boost module
@@ -160,12 +130,8 @@ jobs:
           EOF
 
       - name: Install dependencies (Debug)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-dbg
-
           conan install conanfile.py                  \
              --build='missing'                        \
              -pr:b="$CONAN_DEFAULT_PROFILE_PATH"      \
@@ -179,12 +145,8 @@ jobs:
           rm -r cmake-prefix-dbg
 
       - name: Install dependencies (Release)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-rel
-
           conan install conanfile.py                  \
              --build='missing'                        \
              -pr:b="$CONAN_DEFAULT_PROFILE_PATH"      \
@@ -198,12 +160,8 @@ jobs:
           rm -r cmake-prefix-rel
 
       - name: Install dependencies (RelWithDebInfo)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rwdi.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-rwdi
-
           conan install conanfile.py                  \
              --build='missing'                        \
              -pr:b="$CONAN_DEFAULT_PROFILE_PATH"      \
@@ -217,7 +175,7 @@ jobs:
           rm -r cmake-prefix-rwdi
 
       - name: Clean Conan cache (post-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -225,53 +183,13 @@ jobs:
 
       - name: Save Conan cache
         uses: actions/cache/save@v4
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Evict old CMake configs from cache
-        if: steps.cache-conan.outputs.cache-hit != 'true'
-        run: |
-          apt-get update
-          apt-get install -q -y gh
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}  || true
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-rel-key }}  || true
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-rwdi-key }} || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save CMake configs (Debug)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Save CMake configs (Release)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: /tmp/cmake-prefix-rel.tar
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Save CMake configs (RelWithDebInfo)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rwdi.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rwdi-key }}
-          path: /tmp/cmake-prefix-rwdi.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
         env:
           ZSTD_CLEVEL: 19

--- a/.github/workflows/build-conan-deps-macos.yml
+++ b/.github/workflows/build-conan-deps-macos.yml
@@ -9,12 +9,6 @@ on:
       conan-key:
         description: "Conan packages"
         value: ${{ jobs.build-deps.outputs.conan-key }}
-      cmake-prefix-debug-key:
-        description: "CMake config dir (Debug)"
-        value: ${{ jobs.build-deps.outputs.cmake-dbg-key }}
-      cmake-prefix-release-key:
-        description: "CMake config dir (Release)"
-        value: ${{ jobs.build-deps.outputs.cmake-rel-key }}
 
     inputs:
       conan-version:
@@ -44,9 +38,6 @@ jobs:
     name: Build dependencies with Conan (${{ inputs.os }})
     runs-on: ${{ inputs.os }}
 
-    permissions:
-      actions: write
-
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
       CONAN_HOME: "${{ github.workspace }}/.conan2"
@@ -54,8 +45,6 @@ jobs:
 
     outputs:
       conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
-      cmake-dbg-key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-      cmake-rel-key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
 
     steps:
       - name: Checkout conanfile.py
@@ -74,49 +63,39 @@ jobs:
           suffix="${{ inputs.os }}-$compiler-c++${{ inputs.cppstd }}-$hash"
 
           echo "conan-key=conan-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-dbg-key=cmake-dbg-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-rel-key=cmake-rel-$suffix" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Restore CMake configs (Debug) cache
-        id: cache-cmake-dbg
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-          lookup-only: true
-
-      - name: Restore CMake configs (Release) cache
-        id: cache-cmake-rel
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: /tmp/cmake-prefix-rel.tar
-          lookup-only: true
-
-      - name: Restore package cache
-        id: cache-conan
+      - name: Lookup package cache
+        id: lookup-conan-cache
         uses: actions/cache/restore@v4
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+          lookup-only: true
+
+      - name: Restore package cache
+        uses: actions/cache/restore@v4
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
 
       - uses: actions/setup-python@v5
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         with:
           python-version: "3.12"
 
       - name: Update build deps
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true'     ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: pip install "conan==${{ inputs.conan-version }}"
 
       - name: Configure Conan
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true'     ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan profile detect --force
 
@@ -128,7 +107,7 @@ jobs:
           EOF
 
       - name: Clean Conan cache (pre-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -136,12 +115,8 @@ jobs:
           conan remove --confirm "*"
 
       - name: Install dependencies (Debug)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-dbg
-
           conan install conanfile.py                  \
              --build='missing'                        \
              -pr:b=default                            \
@@ -155,12 +130,8 @@ jobs:
           rm -r cmake-prefix-dbg
 
       - name: Install dependencies (Release)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-rel
-
           conan install conanfile.py                  \
              --build='missing'                        \
              -pr:b=default                            \
@@ -174,7 +145,7 @@ jobs:
           rm -r cmake-prefix-rel
 
       - name: Clean Conan cache (post-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -182,39 +153,12 @@ jobs:
 
       - name: Save Conan cache
         uses: actions/cache/save@v4
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Evict old CMake configs from cache
-        if: steps.cache-conan.outputs.cache-hit != 'true'
-        run: |
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-dbg-key }} || true
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-rel-key }} || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save CMake configs (Debug)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Save CMake configs (Release)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: /tmp/cmake-prefix-rel.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
         env:
           ZSTD_CLEVEL: 19

--- a/.github/workflows/build-conan-deps-windows.yml
+++ b/.github/workflows/build-conan-deps-windows.yml
@@ -9,12 +9,6 @@ on:
       conan-key:
         description: "Conan packages"
         value: ${{ jobs.build-deps.outputs.conan-key }}
-      cmake-prefix-debug-key:
-        description: "CMake config dir (Debug)"
-        value: ${{ jobs.build-deps.outputs.cmake-dbg-key }}
-      cmake-prefix-release-key:
-        description: "CMake config dir (Release)"
-        value: ${{ jobs.build-deps.outputs.cmake-rel-key }}
 
     inputs:
       conan-version:
@@ -44,17 +38,12 @@ jobs:
     name: Build dependencies with Conan (${{ inputs.os }})
     runs-on: ${{ inputs.os }}
 
-    permissions:
-      actions: write
-
     env:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
       CONAN_HOME: "${{ github.workspace }}\\.conan2"
 
     outputs:
       conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
-      cmake-dbg-key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-      cmake-rel-key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
 
     steps:
       - name: Checkout conanfile.py
@@ -77,49 +66,39 @@ jobs:
           suffix="${{ inputs.os }}-$compiler-c++${{ inputs.cppstd }}-$hash"
 
           echo "conan-key=conan-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-dbg-key=cmake-dbg-$suffix" | tee -a "$GITHUB_OUTPUT"
-          echo "cmake-rel-key=cmake-rel-$suffix" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Restore CMake configs (Debug) cache
-        id: cache-cmake-dbg
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: ${{ github.workspace }}\cmake-prefix-dbg.tar
-          lookup-only: true
-
-      - name: Restore CMake configs (Release) cache
-        id: cache-cmake-rel
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: ${{ github.workspace }}\cmake-prefix-rel.tar
-          lookup-only: true
-
-      - name: Restore package cache
-        id: cache-conan
+      - name: Lookup package cache
+        id: lookup-conan-cache
         uses: actions/cache/restore@v4
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}\p
+          path: |
+            ${{ env.CONAN_HOME }}\p
+            ${{ github.workspace }}\cmake-prefix-dbg.tar
+            ${{ github.workspace }}\cmake-prefix-rel.tar
+          lookup-only: true
+
+      - name: Restore package cache
+        uses: actions/cache/restore@v4
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: |
+            ${{ env.CONAN_HOME }}\p
+            ${{ github.workspace }}\cmake-prefix-dbg.tar
+            ${{ github.workspace }}\cmake-prefix-rel.tar
 
       - uses: actions/setup-python@v5
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         with:
           python-version: "3.12"
 
       - name: Update build deps
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true'     ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: pip install "conan==${{ inputs.conan-version }}"
 
       - name: Configure Conan
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true'     ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan profile detect --force
           conan_profile="$(conan profile path default)"
@@ -134,7 +113,7 @@ jobs:
           EOF
 
       - name: Clean Conan cache (pre-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -142,12 +121,8 @@ jobs:
           conan remove --confirm "*"
 
       - name: Install dependencies (Debug)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-dbg
-
           conan install conanfile.py                  \
              --build='missing'                        \
              --build="b2/*"                           \
@@ -164,12 +139,8 @@ jobs:
           rm -r cmake-prefix-dbg
 
       - name: Install dependencies (Release)
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
-          rm -rf cmake-prefix-rel
-
           conan install conanfile.py                  \
              --build='missing'                        \
              --build="b2/*"                           \
@@ -186,7 +157,7 @@ jobs:
           rm -r cmake-prefix-rel
 
       - name: Clean Conan cache (post-build)
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         run: |
           conan cache clean "*" --build
           conan cache clean "*" --download
@@ -194,39 +165,12 @@ jobs:
 
       - name: Save Conan cache
         uses: actions/cache/save@v4
-        if: steps.cache-conan.outputs.cache-hit != 'true'
+        if: steps.lookup-conan-cache.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.generate-cache-key.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}\p
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Evict old CMake configs from cache
-        if: steps.cache-conan.outputs.cache-hit != 'true'
-        run: |
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-dbg-key }} || true
-          gh cache delete --repo '${{ github.repository }}' ${{ steps.generate-cache-key.outputs.cmake-rel-key }} || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save CMake configs (Debug)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-dbg.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-dbg-key }}
-          path: ${{ github.workspace }}\cmake-prefix-dbg.tar
-        env:
-          ZSTD_CLEVEL: 19
-
-      - name: Save CMake configs (Release)
-        uses: actions/cache/save@v4
-        if: |
-          steps.cache-conan.outputs.cache-hit != 'true' ||
-          steps.cache-cmake-rel.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.generate-cache-key.outputs.cmake-rel-key }}
-          path: ${{ github.workspace }}\cmake-prefix-rel.tar
+          path: |
+            ${{ env.CONAN_HOME }}\p
+            ${{ github.workspace }}\cmake-prefix-dbg.tar
+            ${{ github.workspace }}\cmake-prefix-rel.tar
         env:
           ZSTD_CLEVEL: 19

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -54,10 +54,7 @@ jobs:
 
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   build-project:
     name: Build project
@@ -99,14 +96,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-relwithdebinfo-key }}
-          path: /tmp/cmake-prefix-rwdi.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/codeql-cpp.yml
+++ b/.github/workflows/codeql-cpp.yml
@@ -29,10 +29,7 @@ permissions:
 jobs:
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   analyze:
     name: Analyze (C++)
@@ -59,14 +56,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/cppstd.yml
+++ b/.github/workflows/cppstd.yml
@@ -32,22 +32,16 @@ permissions:
 jobs:
   build-conan-deps-cpp20:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
     with:
-      image: ghcr.io/paulsengroup/ci-docker-images/ubuntu-24.04-cxx-clang-19
+      image: ghcr.io/paulsengroup/ci-docker-images/ubuntu-24.04-cxx-clang-20
       cppstd: 20
 
   build-conan-deps-cpp23:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
     with:
-      image: ghcr.io/paulsengroup/ci-docker-images/ubuntu-24.04-cxx-clang-19
+      image: ghcr.io/paulsengroup/ci-docker-images/ubuntu-24.04-cxx-clang-20
       cppstd: 23
 
   build-project:
@@ -100,15 +94,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps-cpp20.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (C++20)
-        if: matrix.cppstd == '20'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-cpp20.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Restore Conan cache (C++23)
@@ -116,15 +106,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps-cpp23.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (C++23)
-        if: matrix.cppstd == '23'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-cpp23.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/fuzzy-testing.yml
+++ b/.github/workflows/fuzzy-testing.yml
@@ -60,10 +60,7 @@ permissions:
 jobs:
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   build-project:
     name: Build project
@@ -95,14 +92,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-relwithdebinfo-key }}
-          path: /tmp/cmake-prefix-rwdi.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -85,19 +85,13 @@ jobs:
 
   build-conan-deps-x86:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-macos.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-macos.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
     with:
       os: macos-13
 
   build-conan-deps-arm64:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-macos.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-macos.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
     with:
       os: macos-14
 
@@ -170,7 +164,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps-x86.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
           fail-on-cache-miss: true
 
       - name: Restore Conan cache (arm64)
@@ -178,45 +175,23 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps-arm64.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
           fail-on-cache-miss: true
 
-      - name: Restore CMake configs (x86; Debug)
-        if: matrix.build_type == 'Debug' && matrix.os == 'macos-13'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-x86.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (x86; Release)
-        if: matrix.build_type == 'Release' && matrix.os == 'macos-13'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-x86.outputs.cmake-prefix-release-key }}
-          path: /tmp/cmake-prefix-rel.tar
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (arm64; Debug)
-        if: matrix.build_type == 'Debug' && (matrix.os == 'macos-14' || matrix.os == 'macos-15')
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-arm64.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (arm64; Release)
-        if: matrix.build_type == 'Release' && (matrix.os == 'macos-14' || matrix.os == 'macos-15')
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps-arm64.outputs.cmake-prefix-release-key }}
-          path: /tmp/cmake-prefix-rel.tar
-          fail-on-cache-miss: true
-
-      - name: Extract CMake configs
+      - name: Extract CMake configs (Debug)
+        if: matrix.build_type == 'Debug'
         run: |
           mkdir conan-env
-          tar -xf /tmp/cmake-prefix-*.tar -C conan-env/ --strip-components=1
+          tar -xf /tmp/cmake-prefix-dbg.tar -C conan-env/ --strip-components=1
+
+      - name: Extract CMake configs (Release)
+        if: matrix.build_type == 'Release'
+        run: |
+          mkdir conan-env
+          tar -xf /tmp/cmake-prefix-rel.tar -C conan-env/ --strip-components=1
 
       - name: Configure project
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -36,10 +36,7 @@ permissions:
 jobs:
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   test-find-package:
     runs-on: ubuntu-latest
@@ -63,14 +60,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-release-key }}
-          path: /tmp/cmake-prefix-rel.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs
@@ -130,14 +124,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-release-key }}
-          path: /tmp/cmake-prefix-rel.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -44,10 +44,7 @@ permissions:
 jobs:
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   build-project:
     name: Build project
@@ -96,14 +93,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
       - name: Extract CMake configs

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -155,10 +155,7 @@ jobs:
 
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-linux.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
 
   build-project:
     name: Build project
@@ -236,29 +233,24 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}/p
+          path: |
+            ${{ env.CONAN_HOME }}/p
+            /tmp/cmake-prefix-dbg.tar
+            /tmp/cmake-prefix-rel.tar
+            /tmp/cmake-prefix-rwdi.tar
           fail-on-cache-miss: true
 
-      - name: Restore CMake configs (Debug)
+      - name: Extract CMake configs (Debug)
         if: matrix.build_type == 'Debug'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-debug-key }}
-          path: /tmp/cmake-prefix-dbg.tar
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (Release)
-        if: matrix.build_type == 'Release'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-release-key }}
-          path: /tmp/cmake-prefix-rel.tar
-          fail-on-cache-miss: true
-
-      - name: Extract CMake configs
         run: |
           mkdir conan-env
-          tar -xf /tmp/cmake-prefix-*.tar -C conan-env/ --strip-components=1
+          tar -xf /tmp/cmake-prefix-dbg.tar -C conan-env/ --strip-components=1
+
+      - name: Extract CMake configs (Release)
+        if: matrix.build_type == 'Release'
+        run: |
+          mkdir conan-env
+          tar -xf /tmp/cmake-prefix-rel.tar -C conan-env/ --strip-components=1
 
       - name: Restore Ccache folder
         id: cache-ccache

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -76,10 +76,7 @@ jobs:
 
   build-conan-deps:
     name: Build Conan deps
-    permissions:
-      actions: write
-      contents: read
-    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-windows.yml@fda0d08dbd667512f523308b77bbb6ba4dcb1d93
+    uses: paulsengroup/hictk/.github/workflows/build-conan-deps-windows.yml@314c7d731a37ea69820f1a96aa81c7da4ed81a83
     with:
       os: windows-2019
 
@@ -117,30 +114,25 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ needs.build-conan-deps.outputs.conan-key }}
-          path: ${{ env.CONAN_HOME }}\p
+          path: |
+            ${{ env.CONAN_HOME }}\p
+            ${{ github.workspace }}\cmake-prefix-dbg.tar
+            ${{ github.workspace }}\cmake-prefix-rel.tar
           fail-on-cache-miss: true
 
-      - name: Restore CMake configs (Debug)
+      - name: Extract CMake configs (Debug)
         if: matrix.build_type == 'Debug'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-debug-key }}
-          path: ${{ github.workspace }}\cmake-prefix-dbg.tar
-          fail-on-cache-miss: true
-
-      - name: Restore CMake configs (Release)
-        if: matrix.build_type == 'Release'
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ needs.build-conan-deps.outputs.cmake-prefix-release-key }}
-          path: ${{ github.workspace }}\cmake-prefix-rel.tar
-          fail-on-cache-miss: true
-
-      - name: Extract CMake configs
         run: |
           mkdir conan-env
           srcdir="$(cygpath '${{ github.workspace }}')"
-          tar -xf "$srcdir/"cmake-prefix-*.tar -C conan-env/ --strip-components=1
+          tar -xf "$srcdir/"cmake-prefix-dbg.tar -C conan-env/ --strip-components=1
+
+      - name: Extract CMake configs (Release)
+        if: matrix.build_type == 'Release'
+        run: |
+          mkdir conan-env
+          srcdir="$(cygpath '${{ github.workspace }}')"
+          tar -xf "$srcdir/"cmake-prefix-rel.tar -C conan-env/ --strip-components=1
 
       - name: Configure project
         run: |


### PR DESCRIPTION
The main issue with the current implementation is that when multiple istances of [build-conan-deps-linux.yml](https://github.com/paulsengroup/hictk/blob/main/.github/workflows/build-conan-deps-linux.yml) are running in parallel, there is a chance that instance 1 saves the Conan cache, while instance 2 restores the CMake profiles.
This can sometimes lead to invalid CMake config files (that is, config files that refer to packages that are not present in the Conan cache).

This PR addresses this issue.