### PR TITLE
[fix]: integration tests

### DIFF
--- a/test/integration/pyproject.toml
+++ b/test/integration/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "pandas==2.3.*",
   "PyYAML",
   "pywin32>=308; platform_system == 'Windows'",
-  "structlog==25.*",
+  "structlog>=25.5,<26",
 ]
 
 optional-dependencies.test = [

--- a/test/integration/src/hictk_integration_suite/cli/logging.py
+++ b/test/integration/src/hictk_integration_suite/cli/logging.py
@@ -147,7 +147,7 @@ def _format_title(title: str) -> str:
 
 def _configure_logger_columns(
     colors: bool,
-    level_styles: Optional[structlog.dev.Styles] = None,
+    level_styles: Optional[structlog.dev.ColumnStyles] = None,
     event_key: str = "event",
     timestamp_key: str = "timestamp",
     pad_level: bool = True,


### PR DESCRIPTION
structlog v25.5 was just released: https://github.com/hynek/structlog/releases/tag/25.5.0.

Despite being a minor release, in the new version `structlog.dev.Styles` was renamed to `structlog.dev.ColumnStyles`, which breaks type annotations in hictk's integration tests.